### PR TITLE
fix: support alternate Apple review RSS URLs

### DIFF
--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ReviewMiningResponse } from '@/lib/analysis/kimi-client';
-import { generateCachedReviewPage } from '@/lib/appstore/cache';
+import { ReviewSourceBreakdown, generateCachedReviewPage } from '@/lib/appstore/cache';
 import { ReviewDiagnostics } from '@/lib/appstore/diagnostics';
 import { normalizeCountry, AppStoreLookupResult } from '@/lib/appstore/discovery';
 import { ReviewStats } from '@/lib/appstore/review-summary';
@@ -23,6 +23,7 @@ interface ResearchResponse {
   source: 'url' | 'id' | 'search';
   stats: ReviewStats;
   reviews: AppStoreReview[];
+  sourceBreakdown?: ReviewSourceBreakdown;
   diagnostics?: ReviewDiagnostics;
   insights: ReviewMiningResponse | null;
   aiError?: string;
@@ -74,6 +75,7 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
         source: page.source,
         stats: page.stats,
         reviews: page.reviews,
+        sourceBreakdown: page.sourceBreakdown,
         diagnostics: page.diagnostics,
         insights: page.insights,
         aiError: page.aiError,

--- a/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
+++ b/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Apple, ArrowLeft, ArrowUpRight, Lightbulb, Star, Target, T
 import { InsightGrid } from '@/components/app-review/insight-cards';
 import { RegenerateButton } from '@/components/app-review/regenerate-button';
 import { SiteFooter } from '@/components/app-review/site-footer';
+import { ReviewSourceBreakdownPanel, reviewSourceLabel } from '@/components/app-review/source-breakdown';
 import { VersionDiagnosticsPanel } from '@/components/app-review/version-diagnostics';
 import {
   CachedAppReviewPage,
@@ -208,7 +209,7 @@ export default async function AppInsightPage({ params }: PageProps) {
                 </h1>
                 <p className="mt-2 text-sm text-zinc-500">{page.app.artistName || 'App Store'} · 更新于 {formatDate(page.updatedAt)}</p>
                 <p className="mt-4 max-w-3xl text-base leading-7 text-zinc-700">
-                  本页基于 App Store 用户评价缓存生成，面向产品分析、竞品研究和搜索引用场景，保留评论证据并用 DeepSeek flash 提炼可行动信号。
+                  本页基于 App Store 用户评价缓存生成，面向产品分析、竞品研究和搜索引用场景，保留评论证据、来源构成和样本边界，并用 DeepSeek flash 提炼可行动信号。
                 </p>
               </div>
             </div>
@@ -273,6 +274,10 @@ export default async function AppInsightPage({ params }: PageProps) {
       </section>
 
       <section className="mx-auto max-w-7xl px-4 pb-6 sm:px-6 lg:px-8">
+        <ReviewSourceBreakdownPanel breakdown={page.sourceBreakdown} />
+      </section>
+
+      <section className="mx-auto max-w-7xl px-4 pb-6 sm:px-6 lg:px-8">
         <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
           <h2 className="text-lg font-semibold text-zinc-950">摘要</h2>
           {insights ? (
@@ -322,7 +327,7 @@ export default async function AppInsightPage({ params }: PageProps) {
                     <div className="min-w-0">
                       <h3 className="break-words text-sm font-semibold leading-6 text-zinc-950">{review.title}</h3>
                       <p className="mt-1 text-xs text-zinc-500">
-                        {review.version || 'Unknown'} · {formatDate(review.updated)} · {review.authorName || '匿名'}
+                        {review.version || 'Unknown'} · {formatDate(review.updated)} · {review.authorName || '匿名'} · {reviewSourceLabel(review.source, review.sourceCountry || review.country)}
                       </p>
                     </div>
                     <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-200 bg-white px-2 py-1 text-xs text-amber-700">

--- a/src/components/app-review/home-client.tsx
+++ b/src/components/app-review/home-client.tsx
@@ -17,6 +17,11 @@ import {
 } from 'lucide-react';
 import { InsightGrid } from '@/components/app-review/insight-cards';
 import { SiteAffordances, SiteFooter } from '@/components/app-review/site-footer';
+import {
+  ReviewSourceBreakdown,
+  ReviewSourceBreakdownPanel,
+  reviewSourceLabel,
+} from '@/components/app-review/source-breakdown';
 import { AppStoreReview } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -74,6 +79,7 @@ interface ResearchData {
   source: 'url' | 'id' | 'search';
   stats: ReviewStats;
   reviews: AppStoreReview[];
+  sourceBreakdown?: ReviewSourceBreakdown;
   insights: ReviewMiningResponse | null;
   aiError?: string;
   pageUrl: string;
@@ -509,6 +515,8 @@ export default function Home({ featuredApps = [] }: { featuredApps?: FeaturedApp
             </div>
           </div>
 
+          <ReviewSourceBreakdownPanel breakdown={result.sourceBreakdown} className="mt-4" />
+
           <section className="mt-4 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <div>
@@ -582,7 +590,7 @@ export default function Home({ featuredApps = [] }: { featuredApps?: FeaturedApp
                     <div className="min-w-0">
                       <h3 className="break-words text-sm font-semibold leading-6 text-zinc-950">{review.title}</h3>
                       <p className="mt-1 text-xs text-zinc-500">
-                        {review.version || 'Unknown'} · {formatDate(review.updated)} · {review.authorName || '匿名'}
+                        {review.version || 'Unknown'} · {formatDate(review.updated)} · {review.authorName || '匿名'} · {reviewSourceLabel(review.source, review.sourceCountry || review.country)}
                       </p>
                     </div>
                     <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-200 bg-white px-2 py-1 text-xs text-amber-700">

--- a/src/components/app-review/source-breakdown.tsx
+++ b/src/components/app-review/source-breakdown.tsx
@@ -1,0 +1,107 @@
+import { Database, Globe2, Rss } from 'lucide-react';
+
+export interface ReviewSourceCountryBreakdown {
+  country: string;
+  count: number;
+  rssCount: number;
+  htmlCount: number;
+}
+
+export interface ReviewSourceBreakdown {
+  total: number;
+  rssCount: number;
+  htmlCount: number;
+  unknownCount: number;
+  countryCount: number;
+  countries: ReviewSourceCountryBreakdown[];
+  note: string;
+  trackedReviewCount?: number;
+  statsTotal?: number;
+  estimated?: boolean;
+}
+
+interface ReviewSourceBreakdownPanelProps {
+  breakdown?: ReviewSourceBreakdown;
+  className?: string;
+}
+
+function formatCountry(country: string) {
+  if (country === 'multi') return '多区';
+  return country.toUpperCase();
+}
+
+function countrySummary(countries: ReviewSourceCountryBreakdown[]) {
+  if (countries.length === 0) return '暂无国家/地区样本';
+  return countries
+    .slice(0, 6)
+    .map((item) => `${formatCountry(item.country)} ${item.count}`)
+    .join(' · ');
+}
+
+export function reviewSourceLabel(source?: string, country?: string) {
+  const sourceText = source === 'app-store-html'
+    ? '页面补样本'
+    : source === 'apple-rss'
+      ? 'RSS 最近评论'
+      : '来源待识别';
+  const countryText = country ? ` · ${formatCountry(country)}` : '';
+  return `${sourceText}${countryText}`;
+}
+
+export function ReviewSourceBreakdownPanel({ breakdown, className = '' }: ReviewSourceBreakdownPanelProps) {
+  if (!breakdown || breakdown.total === 0) return null;
+  const hasPartialTracking = Boolean(
+    breakdown.trackedReviewCount && breakdown.trackedReviewCount < breakdown.total
+  );
+
+  return (
+    <section className={`rounded-lg border border-zinc-200 bg-white p-5 shadow-sm ${className}`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-950">数据来源</h2>
+          <p className="mt-1 text-sm text-zinc-500">展示本页评论样本的抓取构成和边界。</p>
+        </div>
+        <span className="rounded-full border border-zinc-200 bg-zinc-50 px-3 py-1 text-xs text-zinc-500">
+          {hasPartialTracking
+            ? `${breakdown.trackedReviewCount} 条可追踪 / ${breakdown.total} 条统计`
+            : `${breakdown.total} 条样本`}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <div className="rounded-md border border-zinc-100 bg-zinc-50 p-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-zinc-900">
+            <Rss className="h-4 w-4 text-sky-600" />
+            RSS 最近评论
+          </div>
+          <p className="mt-2 text-2xl font-semibold text-zinc-950">{breakdown.rssCount}</p>
+          <p className="mt-1 text-xs text-zinc-500">通常包含版本号和较新的评论时间。</p>
+        </div>
+        <div className="rounded-md border border-zinc-100 bg-zinc-50 p-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-zinc-900">
+            <Database className="h-4 w-4 text-teal-600" />
+            页面补样本
+          </div>
+          <p className="mt-2 text-2xl font-semibold text-zinc-950">{breakdown.htmlCount}</p>
+          <p className="mt-1 text-xs text-zinc-500">来自 App Store 页面服务端渲染的评论块。</p>
+        </div>
+        <div className="rounded-md border border-zinc-100 bg-zinc-50 p-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-zinc-900">
+            <Globe2 className="h-4 w-4 text-amber-600" />
+            Storefront
+          </div>
+          <p className="mt-2 text-2xl font-semibold text-zinc-950">{breakdown.countryCount}</p>
+          <p className="mt-1 truncate text-xs text-zinc-500" title={countrySummary(breakdown.countries)}>
+            {countrySummary(breakdown.countries)}
+          </p>
+        </div>
+      </div>
+
+      <p className="mt-3 text-xs leading-5 text-zinc-500">
+        {breakdown.estimated ? '旧缓存估算。' : ''}
+        {breakdown.note}
+        {breakdown.unknownCount > 0 ? ` 另有 ${breakdown.unknownCount} 条旧缓存评论来源无法识别。` : ''}
+      </p>
+    </section>
+  );
+}

--- a/src/lib/appstore/cache.ts
+++ b/src/lib/appstore/cache.ts
@@ -13,11 +13,31 @@ import {
 } from '@/lib/appstore/discovery';
 import { ReviewDiagnostics, buildReviewDiagnostics } from '@/lib/appstore/diagnostics';
 import { ReviewStats, sortReviewsForAnalysis, summarizeReviews } from '@/lib/appstore/review-summary';
-import { AppStoreReview } from '@/types';
+import { AppReviewSource, AppStoreReview } from '@/types';
 
 export interface CachedModelInfo {
   provider: string;
   model: string;
+}
+
+export interface ReviewSourceCountryBreakdown {
+  country: string;
+  count: number;
+  rssCount: number;
+  htmlCount: number;
+}
+
+export interface ReviewSourceBreakdown {
+  total: number;
+  rssCount: number;
+  htmlCount: number;
+  unknownCount: number;
+  countryCount: number;
+  countries: ReviewSourceCountryBreakdown[];
+  note: string;
+  trackedReviewCount?: number;
+  statsTotal?: number;
+  estimated?: boolean;
 }
 
 export interface CachedAppReviewPage {
@@ -30,6 +50,7 @@ export interface CachedAppReviewPage {
   source: AppResolution['source'];
   stats: ReviewStats;
   reviews: AppStoreReview[];
+  sourceBreakdown?: ReviewSourceBreakdown;
   diagnostics?: ReviewDiagnostics;
   insights: ReviewMiningResponse | null;
   aiError?: string;
@@ -132,6 +153,149 @@ function pageCountForLimit(limit: number) {
   return Math.min(Math.max(Math.ceil(limit / 50), 1), 8);
 }
 
+function inferReviewSource(review: AppStoreReview): AppReviewSource | 'unknown' {
+  if (review.source === 'apple-rss' || review.source === 'app-store-html') {
+    return review.source;
+  }
+
+  if (review.contentTypeLabel === 'Review' || review.link?.includes('apps.apple.com')) {
+    return 'app-store-html';
+  }
+
+  if (review.link?.includes('itunes.apple.com') || (review.version && review.version !== 'Unknown')) {
+    return 'apple-rss';
+  }
+
+  return 'unknown';
+}
+
+export function buildReviewSourceBreakdown(reviews: AppStoreReview[], primaryCountry: string): ReviewSourceBreakdown {
+  const countryBuckets = new Map<string, ReviewSourceCountryBreakdown>();
+  let rssCount = 0;
+  let htmlCount = 0;
+  let unknownCount = 0;
+
+  for (const review of reviews) {
+    const source = inferReviewSource(review);
+    const country = normalizeCountry(review.sourceCountry || review.country || primaryCountry);
+    const bucket = countryBuckets.get(country) || {
+      country,
+      count: 0,
+      rssCount: 0,
+      htmlCount: 0,
+    };
+
+    bucket.count += 1;
+
+    if (source === 'apple-rss') {
+      rssCount += 1;
+      bucket.rssCount += 1;
+    } else if (source === 'app-store-html') {
+      htmlCount += 1;
+      bucket.htmlCount += 1;
+    } else {
+      unknownCount += 1;
+    }
+
+    countryBuckets.set(country, bucket);
+  }
+
+  return {
+    total: reviews.length,
+    rssCount,
+    htmlCount,
+    unknownCount,
+    countryCount: countryBuckets.size,
+    countries: Array.from(countryBuckets.values()).sort((a, b) => b.count - a.count),
+    note: 'RSS 提供所选国家/地区的最近评论；App Store 页面补样本来自 Apple 页面展示的精选/有帮助评论，多 storefront 去重后用于补充样本，不代表全量评论库。',
+  };
+}
+
+function buildLegacyEstimatedSourceBreakdown(
+  page: CachedAppReviewPage,
+  trackedBreakdown: ReviewSourceBreakdown,
+  primaryCountry: string
+): ReviewSourceBreakdown {
+  const statsTotal = page.reviewSampleSize || page.stats?.totalReviews || trackedBreakdown.total;
+
+  if (statsTotal <= trackedBreakdown.total) {
+    return trackedBreakdown;
+  }
+
+  const unknownVersionCount = page.stats?.versionDistribution
+    ?.find((item) => item.version === 'Unknown')?.count || 0;
+
+  if (unknownVersionCount <= trackedBreakdown.htmlCount) {
+    return {
+      ...trackedBreakdown,
+      statsTotal,
+      trackedReviewCount: trackedBreakdown.total,
+      note: `${trackedBreakdown.note} 旧缓存只保存了 ${trackedBreakdown.total} 条评论证据，来源构成按可追踪证据展示。`,
+    };
+  }
+
+  const htmlCount = unknownVersionCount;
+  const rssCount = Math.max(0, statsTotal - htmlCount);
+  const countries = [
+    rssCount > 0 ? {
+      country: normalizeCountry(primaryCountry),
+      count: rssCount,
+      rssCount,
+      htmlCount: 0,
+    } : null,
+    htmlCount > 0 ? {
+      country: 'multi',
+      count: htmlCount,
+      rssCount: 0,
+      htmlCount,
+    } : null,
+  ].filter((item): item is ReviewSourceCountryBreakdown => Boolean(item));
+
+  return {
+    total: statsTotal,
+    rssCount,
+    htmlCount,
+    unknownCount: 0,
+    countryCount: countries.length,
+    countries,
+    note: '这是旧缓存的来源估算：RSS 数量按统计样本总数减去 Unknown 版本样本推断，页面补样本按 Unknown 版本桶推断；新生成缓存会写入精确来源国家/地区。',
+    trackedReviewCount: trackedBreakdown.total,
+    statsTotal,
+    estimated: true,
+  };
+}
+
+function hydrateReviewSource(review: AppStoreReview, primaryCountry: string): AppStoreReview {
+  const source = inferReviewSource(review);
+  return {
+    ...review,
+    source: source === 'unknown' ? review.source : source,
+    sourceCountry: review.sourceCountry || review.country || primaryCountry,
+  };
+}
+
+function hydrateCachedReviewPage(page: CachedAppReviewPage): CachedAppReviewPage {
+  const primaryCountry = page.app?.country || 'us';
+  const reviews = (page.reviews || []).map((review) => hydrateReviewSource(review, primaryCountry));
+
+  if (page.sourceBreakdown) {
+    return {
+      ...page,
+      reviews,
+    };
+  }
+
+  return {
+    ...page,
+    reviews,
+    sourceBreakdown: buildLegacyEstimatedSourceBreakdown(
+      page,
+      buildReviewSourceBreakdown(reviews, primaryCountry),
+      primaryCountry
+    ),
+  };
+}
+
 function safeErrorMessage(error: unknown) {
   if (!(error instanceof Error)) return '未知错误';
   if (/api[_-]?key|authorization|secret|token/i.test(error.message)) {
@@ -168,7 +332,7 @@ async function resolveApp(options: GenerateCachedReviewOptions): Promise<AppReso
 export async function readCachedReviewPage(country: string, appId: string): Promise<CachedAppReviewPage | null> {
   try {
     const content = await fs.readFile(cacheFilePath(country, appId), 'utf8');
-    return JSON.parse(content) as CachedAppReviewPage;
+    return hydrateCachedReviewPage(JSON.parse(content) as CachedAppReviewPage);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
     throw error;
@@ -184,7 +348,7 @@ export async function listCachedReviewPages(): Promise<CachedAppReviewPage[]> {
         .map(async (file) => {
           try {
             const content = await fs.readFile(path.join(cacheRoot(), file), 'utf8');
-            return JSON.parse(content) as CachedAppReviewPage;
+            return hydrateCachedReviewPage(JSON.parse(content) as CachedAppReviewPage);
           } catch {
             return null;
           }
@@ -272,6 +436,7 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
 
   const sortedReviews = sortReviewsForAnalysis(reviews);
   const stats = summarizeReviews(reviews);
+  const sourceBreakdown = buildReviewSourceBreakdown(reviews, country);
   let insights: ReviewMiningResponse | null = null;
   let aiError: string | undefined;
   let model: CachedModelInfo | undefined;
@@ -311,6 +476,7 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
     source: resolution.source,
     stats,
     reviews: sortedReviews.slice(0, Math.min(maxReviews, 80)),
+    sourceBreakdown,
     diagnostics: buildReviewDiagnostics(reviews),
     insights,
     aiError,

--- a/src/lib/appstore/cache.ts
+++ b/src/lib/appstore/cache.ts
@@ -255,6 +255,21 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
     return { page: existing, cached: true };
   }
 
+  if (reviews.length === 0 && (resolution.app.userRatingCount || 0) > 0) {
+    if (existing && existing.stats.totalReviews > 0) {
+      console.warn('Skipping cache overwrite because App Store returned no reviews for an app with public ratings', {
+        appId: resolution.app.id,
+        country,
+        userRatingCount: resolution.app.userRatingCount,
+        existingReviews: existing.stats.totalReviews,
+        existingUpdatedAt: existing.updatedAt,
+      });
+      return { page: existing, cached: true };
+    }
+
+    throw new Error(`App Store 暂时没有返回 ${resolution.app.name} 的评论正文，但该应用有 ${resolution.app.userRatingCount} 个评分。请稍后重新生成。`);
+  }
+
   const sortedReviews = sortReviewsForAnalysis(reviews);
   const stats = summarizeReviews(reviews);
   let insights: ReviewMiningResponse | null = null;

--- a/src/lib/appstore/fetcher.ts
+++ b/src/lib/appstore/fetcher.ts
@@ -133,35 +133,50 @@ export class AppStoreFetcher {
    * 抓取指定页面的评论
    */
   private static async fetchPageReviews(appId: string, country: string, page: number): Promise<AppStoreReview[]> {
-    const url = `${this.BASE_URL}/${country}/rss/customerreviews/id=${appId}/page=${page}/json`;
+    const urls = this.buildReviewUrls(appId, country, page);
 
     try {
-      console.log(`Making request to: ${url}`);
-      const response = await this.fetchWithRetry(url);
-      console.log(`Response received, status: ${response.status}`);
+      for (const url of urls) {
+        console.log(`Making request to: ${url}`);
+        const response = await this.fetchWithRetry(url);
+        console.log(`Response received, status: ${response.status}`);
 
-      const data: AppStoreResponse = await response.json();
-      console.log(`JSON parsed successfully`);
+        const data: AppStoreResponse = await response.json();
+        console.log(`JSON parsed successfully`);
 
-      if (!data.feed) {
-        console.warn(`No feed found in response for app ${appId} page ${page}`);
-        return [];
+        if (!data.feed) {
+          console.warn(`No feed found in response for app ${appId} page ${page}`);
+          continue;
+        }
+
+        if (!data.feed.entry) {
+          console.warn(`No entries found in feed for app ${appId} page ${page}`);
+          continue;
+        }
+
+        console.log(`Found ${data.feed.entry.length} entries on page ${page}`);
+        const reviews = this.parseReviews(data.feed.entry, appId, country);
+        console.log(`Parsed ${reviews.length} reviews from page ${page}`);
+
+        if (reviews.length > 0) {
+          return reviews;
+        }
       }
 
-      if (!data.feed.entry) {
-        console.warn(`No entries found in feed for app ${appId} page ${page}`);
-        return [];
-      }
-
-      console.log(`Found ${data.feed.entry.length} entries on page ${page}`);
-      const reviews = this.parseReviews(data.feed.entry, appId, country);
-      console.log(`Parsed ${reviews.length} reviews from page ${page}`);
-
-      return reviews;
+      console.warn(`No reviews found in any RSS URL for app ${appId} page ${page}`);
+      return [];
     } catch (error) {
       console.error(`Failed to fetch page ${page} for app ${appId}:`, error);
       throw error;
     }
+  }
+
+  private static buildReviewUrls(appId: string, country: string, page: number): string[] {
+    return [
+      `${this.BASE_URL}/${country}/rss/customerreviews/id=${appId}/page=${page}/json`,
+      `${this.BASE_URL}/${country}/rss/customerreviews/page=${page}/id=${appId}/sortBy=mostRecent/json`,
+      `${this.BASE_URL}/${country}/rss/customerreviews/page=${page}/id=${appId}/sortby=mostrecent/json`,
+    ];
   }
 
   /**
@@ -171,14 +186,8 @@ export class AppStoreFetcher {
     try {
       // 尝试获取下一页，如果返回空或错误，说明没有更多页面
       const nextPage = currentPage + 1;
-      const url = `${this.BASE_URL}/${country}/rss/customerreviews/id=${appId}/page=${nextPage}/json`;
-
-      const response = await this.fetchWithRetry(url);
-      const data: AppStoreResponse = await response.json();
-
-      // 如果有feed和entry，说明还有更多页面
-      return !!(data.feed && data.feed.entry && data.feed.entry.length > 0);
-    } catch (error) {
+      return (await this.fetchPageReviews(appId, country, nextPage)).length > 0;
+    } catch {
       console.log(`No more pages after page ${currentPage}`);
       return false;
     }

--- a/src/lib/appstore/fetcher.ts
+++ b/src/lib/appstore/fetcher.ts
@@ -333,6 +333,8 @@ export class AppStoreFetcher {
       contentTypeLabel: 'Review',
       appId,
       country,
+      source: 'app-store-html',
+      sourceCountry: country,
     };
   }
 
@@ -490,6 +492,8 @@ export class AppStoreFetcher {
         contentTypeLabel: entry['im:contentType']?.attributes?.label || '',
         appId,
         country,
+        source: 'apple-rss',
+        sourceCountry: country,
       };
     } catch (error) {
       console.warn('Failed to parse review entry:', error);

--- a/src/lib/appstore/fetcher.ts
+++ b/src/lib/appstore/fetcher.ts
@@ -39,8 +39,19 @@ interface AppStoreResponse {
   };
 }
 
+interface AppStoreWebReview {
+  '$kind'?: string;
+  id?: string;
+  title?: string;
+  date?: string;
+  contents?: string;
+  rating?: number;
+  reviewerName?: string;
+}
+
 export class AppStoreFetcher {
   private static readonly BASE_URL = 'https://itunes.apple.com';
+  private static readonly APP_STORE_WEB_URL = 'https://apps.apple.com';
   private static readonly MAX_RETRIES = 3;
   private static readonly RETRY_DELAY = 1000; // 1 second
 
@@ -114,6 +125,14 @@ export class AppStoreFetcher {
 
       console.log(`Fetch completed. Total reviews: ${allReviews.length}`);
 
+      if (allReviews.length === 0) {
+        const htmlReviews = await this.fetchHtmlReviews(appId, country, maxReviews);
+        if (htmlReviews.length > 0) {
+          console.log(`Using App Store HTML fallback. Total reviews: ${htmlReviews.length}`);
+          allReviews.push(...htmlReviews);
+        }
+      }
+
       // 去重处理（基于评论ID）
       const uniqueReviews = this.deduplicateReviews(allReviews);
       console.log(`After deduplication: ${uniqueReviews.length} unique reviews`);
@@ -177,6 +196,94 @@ export class AppStoreFetcher {
       `${this.BASE_URL}/${country}/rss/customerreviews/page=${page}/id=${appId}/sortBy=mostRecent/json`,
       `${this.BASE_URL}/${country}/rss/customerreviews/page=${page}/id=${appId}/sortby=mostrecent/json`,
     ];
+  }
+
+  /**
+   * Apple RSS 对部分 App 会按出口 IP/UA 返回空 feed；App Store 页面首屏仍包含评论数据。
+   */
+  private static async fetchHtmlReviews(appId: string, country: string, maxReviews: number): Promise<AppStoreReview[]> {
+    const url = `${this.APP_STORE_WEB_URL}/${country}/app/id${appId}`;
+
+    try {
+      console.log(`Trying App Store HTML fallback: ${url}`);
+      const html = await this.fetchTextWithRetry(url, {
+        Accept: 'text/html,application/xhtml+xml',
+      });
+      const reviews = this.parseHtmlReviews(html, appId, country);
+      console.log(`Parsed ${reviews.length} reviews from App Store HTML fallback`);
+      return reviews.slice(0, maxReviews);
+    } catch (error) {
+      console.warn(`App Store HTML fallback failed for app ${appId}:`, error);
+      return [];
+    }
+  }
+
+  private static parseHtmlReviews(html: string, appId: string, country: string): AppStoreReview[] {
+    const match = html.match(/<script type="application\/json" id="serialized-server-data">([\s\S]*?)<\/script>/);
+    if (!match?.[1]) return [];
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(match[1]);
+    } catch (error) {
+      console.warn('Failed to parse App Store serialized server data:', error);
+      return [];
+    }
+
+    const reviews: AppStoreReview[] = [];
+    const seen = new Set<string>();
+    const stack: unknown[] = [payload];
+
+    while (stack.length > 0) {
+      const item = stack.pop();
+      if (!item) continue;
+
+      if (Array.isArray(item)) {
+        for (const child of item) stack.push(child);
+        continue;
+      }
+
+      if (typeof item !== 'object') continue;
+      const record = item as Record<string, unknown>;
+
+      if (record.$kind === 'Review') {
+        const review = this.parseWebReview(record as AppStoreWebReview, appId, country);
+        if (review && !seen.has(review.id)) {
+          seen.add(review.id);
+          reviews.push(review);
+        }
+      }
+
+      for (const value of Object.values(record)) {
+        if (value && (typeof value === 'object')) {
+          stack.push(value);
+        }
+      }
+    }
+
+    return reviews;
+  }
+
+  private static parseWebReview(review: AppStoreWebReview, appId: string, country: string): AppStoreReview | null {
+    if (!review.id || !review.title || !review.contents || !review.rating) return null;
+
+    return {
+      id: review.id,
+      updated: review.date || new Date().toISOString(),
+      rating: String(review.rating),
+      version: 'Unknown',
+      title: review.title,
+      content: review.contents,
+      contentType: 'text',
+      authorName: review.reviewerName || 'App Store 用户',
+      authorUri: '',
+      voteCount: '0',
+      voteSum: '0',
+      link: `${this.APP_STORE_WEB_URL}/${country}/app/id${appId}?see-all=reviews`,
+      contentTypeLabel: 'Review',
+      appId,
+      country,
+    };
   }
 
   /**
@@ -248,6 +355,38 @@ export class AppStoreFetcher {
     }
     
     throw new Error('All fetch attempts failed');
+  }
+
+  private static async fetchTextWithRetry(url: string, headers: HeadersInit, retries = this.MAX_RETRIES): Promise<string> {
+    for (let i = 0; i < retries; i++) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+        const response = await fetch(url, {
+          headers,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timeoutId);
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        return response.text();
+      } catch (error) {
+        console.warn(`Text fetch attempt ${i + 1} failed:`, error);
+
+        if (i === retries - 1) {
+          throw error;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, this.RETRY_DELAY * (i + 1)));
+      }
+    }
+
+    throw new Error('All text fetch attempts failed');
   }
 
   /**

--- a/src/lib/appstore/fetcher.ts
+++ b/src/lib/appstore/fetcher.ts
@@ -52,6 +52,27 @@ interface AppStoreWebReview {
 export class AppStoreFetcher {
   private static readonly BASE_URL = 'https://itunes.apple.com';
   private static readonly APP_STORE_WEB_URL = 'https://apps.apple.com';
+  private static readonly HTML_FALLBACK_COUNTRIES = [
+    'cn',
+    'us',
+    'hk',
+    'tw',
+    'sg',
+    'jp',
+    'gb',
+    'ca',
+    'au',
+    'de',
+    'my',
+    'th',
+    'kr',
+    'in',
+    'br',
+    'ie',
+    'it',
+    'nl',
+    'ch',
+  ];
   private static readonly MAX_RETRIES = 3;
   private static readonly RETRY_DELAY = 1000; // 1 second
 
@@ -125,10 +146,10 @@ export class AppStoreFetcher {
 
       console.log(`Fetch completed. Total reviews: ${allReviews.length}`);
 
-      if (allReviews.length === 0) {
-        const htmlReviews = await this.fetchHtmlReviews(appId, country, maxReviews);
+      if (!incremental && allReviews.length < maxReviews) {
+        const htmlReviews = await this.fetchHtmlReviews(appId, country, maxReviews - allReviews.length);
         if (htmlReviews.length > 0) {
-          console.log(`Using App Store HTML fallback. Total reviews: ${htmlReviews.length}`);
+          console.log(`Using App Store HTML supplemental reviews. Total supplemental reviews: ${htmlReviews.length}`);
           allReviews.push(...htmlReviews);
         }
       }
@@ -202,20 +223,49 @@ export class AppStoreFetcher {
    * Apple RSS 对部分 App 会按出口 IP/UA 返回空 feed；App Store 页面首屏仍包含评论数据。
    */
   private static async fetchHtmlReviews(appId: string, country: string, maxReviews: number): Promise<AppStoreReview[]> {
-    const url = `${this.APP_STORE_WEB_URL}/${country}/app/id${appId}`;
+    const countries = this.buildHtmlFallbackCountries(country);
+    const allReviews: AppStoreReview[] = [];
+    const seen = new Set<string>();
 
-    try {
-      console.log(`Trying App Store HTML fallback: ${url}`);
-      const html = await this.fetchTextWithRetry(url, {
-        Accept: 'text/html,application/xhtml+xml',
-      });
-      const reviews = this.parseHtmlReviews(html, appId, country);
-      console.log(`Parsed ${reviews.length} reviews from App Store HTML fallback`);
-      return reviews.slice(0, maxReviews);
-    } catch (error) {
-      console.warn(`App Store HTML fallback failed for app ${appId}:`, error);
-      return [];
+    for (const fallbackCountry of countries) {
+      const url = `${this.APP_STORE_WEB_URL}/${fallbackCountry}/app/id${appId}`;
+
+      try {
+        console.log(`Trying App Store HTML fallback: ${url}`);
+        const html = await this.fetchTextWithRetry(url, {
+          Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        }, 1, 12000);
+        const reviews = this.parseHtmlReviews(html, appId, fallbackCountry);
+        let added = 0;
+
+        for (const review of reviews) {
+          if (seen.has(review.id)) continue;
+          seen.add(review.id);
+          allReviews.push(review);
+          added++;
+        }
+
+        console.log(`Parsed ${reviews.length} HTML reviews from ${fallbackCountry}; added ${added}; total ${allReviews.length}`);
+
+        if (allReviews.length >= maxReviews) {
+          break;
+        }
+      } catch (error) {
+        console.warn(`App Store HTML fallback failed for app ${appId} in ${fallbackCountry}:`, error);
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 150));
     }
+
+    return allReviews.slice(0, maxReviews);
+  }
+
+  private static buildHtmlFallbackCountries(country: string): string[] {
+    const normalizedCountry = country.toLowerCase();
+    return [
+      normalizedCountry,
+      ...this.HTML_FALLBACK_COUNTRIES.filter((fallbackCountry) => fallbackCountry !== normalizedCountry),
+    ];
   }
 
   private static parseHtmlReviews(html: string, appId: string, country: string): AppStoreReview[] {
@@ -357,11 +407,16 @@ export class AppStoreFetcher {
     throw new Error('All fetch attempts failed');
   }
 
-  private static async fetchTextWithRetry(url: string, headers: HeadersInit, retries = this.MAX_RETRIES): Promise<string> {
+  private static async fetchTextWithRetry(
+    url: string,
+    headers: HeadersInit,
+    retries = this.MAX_RETRIES,
+    timeoutMs = 15000
+  ): Promise<string> {
     for (let i = 0; i < retries; i++) {
       try {
         const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 15000);
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
         const response = await fetch(url, {
           headers,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,8 @@ export interface App {
   lastFetched?: string;
 }
 
+export type AppReviewSource = 'apple-rss' | 'app-store-html';
+
 // AppStore 评论原始数据类型
 export interface AppStoreReview {
   id: string;
@@ -23,6 +25,8 @@ export interface AppStoreReview {
   contentTypeLabel: string;
   appId: string;
   country: string;
+  source?: AppReviewSource;
+  sourceCountry?: string;
 }
 
 // 分析结果类型


### PR DESCRIPTION
## Summary
- Try alternate Apple customer review RSS URL formats when the default feed returns no entries
- Fall back to parsing App Store web page serialized server data reviews when RSS is empty from the production VPS出口
- Supplement partial RSS results with multi-storefront App Store HTML reviews until the requested sample size is reached
- Avoid treating a zero-review or lower-review fetch as a valid cache when a stronger cache already exists
- Add review source metadata and source breakdowns for Apple RSS vs App Store HTML samples
- Surface source breakdowns on homepage results and SEO detail pages, including legacy-cache estimation when only stored evidence is available

## Verification
- npx eslint src/types/index.ts src/lib/appstore/fetcher.ts src/lib/appstore/cache.ts src/app/api/research/route.ts src/components/app-review/source-breakdown.tsx src/components/app-review/home-client.tsx src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
- npm run build in the source deployment repo
- npm run build in this publish repo
- Live health endpoint returns model deepseek-v4-flash
- Live flomo API returns 175 statistical samples with estimated source breakdown: RSS 100, App Store HTML 75
- Live flomo detail page contains 数据来源, 旧缓存估算, CN 100, 多区 75
- Forced flomo refresh hit Apple HTML 429 and cache protection kept the stronger 175-review cache instead of overwriting with 100 reviews
