### PR TITLE
feat: paginate cached apps and add incremental refresh

### DIFF
--- a/src/app/api/research/regenerate/route.ts
+++ b/src/app/api/research/regenerate/route.ts
@@ -11,11 +11,14 @@ interface RegenerateRequest {
   country?: string;
   maxReviews?: number;
   analyze?: boolean;
+  incremental?: boolean;
 }
 
 interface RegenerateResponse {
   pageUrl: string;
   updatedAt: string;
+  cached: boolean;
+  incremental: boolean;
 }
 
 function clampReviewLimit(value: unknown): number {
@@ -41,12 +44,14 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       return NextResponse.json({ success: false, error: '缺少有效 App ID' }, { status: 400 });
     }
 
-    const { page } = await generateCachedReviewPage({
+    const incremental = body.incremental === true;
+    const { page, cached } = await generateCachedReviewPage({
       appId,
       country: normalizeCountry(body.country),
       maxReviews: clampReviewLimit(body.maxReviews),
       analyze: body.analyze !== false,
-      force: true,
+      force: !incremental,
+      incremental,
     });
 
     return NextResponse.json({
@@ -54,6 +59,8 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       data: {
         pageUrl: page.pagePath,
         updatedAt: page.updatedAt,
+        cached,
+        incremental,
       },
     });
   } catch (error) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import AppReviewHome from '@/components/app-review/home-client';
-import { getFeaturedCachedApps } from '@/lib/appstore/cache';
+import { getCachedAppSummaries } from '@/lib/appstore/cache';
 
 export const dynamic = 'force-dynamic';
 
@@ -29,8 +29,22 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function Page() {
-  const featuredApps = await getFeaturedCachedApps(18);
+type PageProps = {
+  searchParams?: Promise<{
+    cachePage?: string;
+  }>;
+};
 
-  return <AppReviewHome featuredApps={featuredApps} />;
+function parseCachePage(value?: string) {
+  const parsed = Number.parseInt(String(value || '1'), 10);
+  if (!Number.isFinite(parsed)) return 1;
+  return Math.max(1, parsed);
+}
+
+export default async function Page({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const featuredApps = await getCachedAppSummaries();
+  const initialCachePage = parseCachePage(params?.cachePage);
+
+  return <AppReviewHome featuredApps={featuredApps} initialCachePage={initialCachePage} />;
 }

--- a/src/components/app-review/home-client.tsx
+++ b/src/components/app-review/home-client.tsx
@@ -131,6 +131,8 @@ const exampleQueries = [
   'https://apps.apple.com/us/app/chatgpt/id6448311069',
 ];
 
+const CACHED_APP_PAGE_SIZE = 12;
+
 function formatDate(value?: string) {
   if (!value) return '未知';
   const date = new Date(value);
@@ -197,22 +199,35 @@ function AppIcon({ app }: { app: AppStoreLookupResult }) {
   );
 }
 
-function FeaturedApps({ apps }: { apps: FeaturedAppSummary[] }) {
+function clampPage(page: number, totalPages: number) {
+  return Math.min(Math.max(page, 1), Math.max(totalPages, 1));
+}
+
+function pageHref(page: number) {
+  return page <= 1 ? '/#cached-apps' : `/?cachePage=${page}#cached-apps`;
+}
+
+function FeaturedApps({ apps, currentPage }: { apps: FeaturedAppSummary[]; currentPage: number }) {
   if (apps.length === 0) return null;
+  const totalPages = Math.ceil(apps.length / CACHED_APP_PAGE_SIZE);
+  const page = clampPage(currentPage, totalPages);
+  const pageApps = apps.slice((page - 1) * CACHED_APP_PAGE_SIZE, page * CACHED_APP_PAGE_SIZE);
+  const pageNumbers = Array.from({ length: totalPages }, (_, index) => index + 1)
+    .filter((item) => item === 1 || item === totalPages || Math.abs(item - page) <= 1);
 
   return (
-    <section className="mx-auto max-w-7xl px-4 pt-6 sm:px-6 lg:px-8">
+    <section id="cached-apps" className="mx-auto max-w-7xl scroll-mt-6 px-4 pt-6 sm:px-6 lg:px-8">
       <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-950">已生成的常用 App 洞察页</h2>
-          <p className="mt-1 text-sm text-zinc-500">搜索后会自动缓存成独立页面；这里优先展示最近生成和常见入口。</p>
+          <h2 className="text-lg font-semibold text-zinc-950">已生成的 App 洞察页</h2>
+          <p className="mt-1 text-sm text-zinc-500">所有搜索生成过的正式缓存都会出现在这里，按最近更新时间分页展示。</p>
         </div>
         <span className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs text-zinc-500">
-          SEO 静态入口
+          共 {apps.length} 个 · 第 {page}/{totalPages} 页
         </span>
       </div>
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {apps.map((app) => (
+        {pageApps.map((app) => (
           <a
             key={`${app.country}-${app.id}`}
             href={app.pagePath}
@@ -247,11 +262,60 @@ function FeaturedApps({ apps }: { apps: FeaturedAppSummary[] }) {
           </a>
         ))}
       </div>
+      {totalPages > 1 ? (
+        <nav className="mt-4 flex flex-wrap items-center justify-center gap-2" aria-label="缓存 App 分页">
+          <a
+            href={pageHref(page - 1)}
+            className={`rounded-md border px-3 py-2 text-sm transition ${
+              page <= 1
+                ? 'pointer-events-none border-zinc-100 bg-zinc-50 text-zinc-300'
+                : 'border-zinc-200 bg-white text-zinc-600 hover:border-zinc-300 hover:text-zinc-950'
+            }`}
+          >
+            上一页
+          </a>
+          {pageNumbers.map((item, index) => {
+            const previous = pageNumbers[index - 1];
+            return (
+              <span key={item} className="inline-flex items-center gap-2">
+                {previous && item - previous > 1 ? <span className="text-sm text-zinc-400">...</span> : null}
+                <a
+                  href={pageHref(item)}
+                  aria-current={item === page ? 'page' : undefined}
+                  className={`min-w-10 rounded-md border px-3 py-2 text-center text-sm transition ${
+                    item === page
+                      ? 'border-zinc-950 bg-zinc-950 text-white'
+                      : 'border-zinc-200 bg-white text-zinc-600 hover:border-zinc-300 hover:text-zinc-950'
+                  }`}
+                >
+                  {item}
+                </a>
+              </span>
+            );
+          })}
+          <a
+            href={pageHref(page + 1)}
+            className={`rounded-md border px-3 py-2 text-sm transition ${
+              page >= totalPages
+                ? 'pointer-events-none border-zinc-100 bg-zinc-50 text-zinc-300'
+                : 'border-zinc-200 bg-white text-zinc-600 hover:border-zinc-300 hover:text-zinc-950'
+            }`}
+          >
+            下一页
+          </a>
+        </nav>
+      ) : null}
     </section>
   );
 }
 
-export default function Home({ featuredApps = [] }: { featuredApps?: FeaturedAppSummary[] }) {
+export default function Home({
+  featuredApps = [],
+  initialCachePage = 1,
+}: {
+  featuredApps?: FeaturedAppSummary[];
+  initialCachePage?: number;
+}) {
   const [query, setQuery] = useState('ChatGPT');
   const [country, setCountry] = useState('cn');
   const [maxReviews, setMaxReviews] = useState(160);
@@ -606,7 +670,7 @@ export default function Home({ featuredApps = [] }: { featuredApps?: FeaturedApp
         </section>
       ) : (
         <>
-          <FeaturedApps apps={featuredApps} />
+          <FeaturedApps apps={featuredApps} currentPage={initialCachePage} />
           <section className="mx-auto grid max-w-7xl gap-4 px-4 py-6 sm:px-6 lg:grid-cols-3 lg:px-8">
             <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
               <TrendingDown className="h-5 w-5 text-rose-600" />

--- a/src/components/app-review/regenerate-button.tsx
+++ b/src/components/app-review/regenerate-button.tsx
@@ -13,23 +13,25 @@ interface RegenerateResponse {
   data?: {
     pageUrl: string;
     updatedAt: string;
+    cached: boolean;
+    incremental: boolean;
   };
   error?: string;
 }
 
 export function RegenerateButton({ appId, country }: RegenerateButtonProps) {
-  const [loading, setLoading] = useState(false);
+  const [loadingMode, setLoadingMode] = useState<'incremental' | 'full' | null>(null);
   const [error, setError] = useState('');
 
-  const regenerate = async () => {
-    setLoading(true);
+  const regenerate = async (incremental: boolean) => {
+    setLoadingMode(incremental ? 'incremental' : 'full');
     setError('');
 
     try {
       const response = await fetch('/api/research/regenerate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ appId, country, maxReviews: 160, analyze: true }),
+        body: JSON.stringify({ appId, country, maxReviews: 400, analyze: true, incremental }),
       });
       const payload = await response.json() as RegenerateResponse;
 
@@ -41,21 +43,32 @@ export function RegenerateButton({ appId, country }: RegenerateButtonProps) {
     } catch (regenerateError) {
       setError(regenerateError instanceof Error ? regenerateError.message : '重新生成失败');
     } finally {
-      setLoading(false);
+      setLoadingMode(null);
     }
   };
 
   return (
     <div className="flex flex-col items-start gap-2">
-      <button
-        type="button"
-        onClick={regenerate}
-        disabled={loading}
-        className="inline-flex items-center gap-2 rounded-md bg-zinc-950 px-3 py-2 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-        重新生成
-      </button>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={() => regenerate(true)}
+          disabled={Boolean(loadingMode)}
+          className="inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm font-medium text-zinc-700 transition hover:border-zinc-300 hover:text-zinc-950 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw className={`h-4 w-4 ${loadingMode === 'incremental' ? 'animate-spin' : ''}`} />
+          增量更新
+        </button>
+        <button
+          type="button"
+          onClick={() => regenerate(false)}
+          disabled={Boolean(loadingMode)}
+          className="inline-flex items-center gap-2 rounded-md bg-zinc-950 px-3 py-2 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <RefreshCw className={`h-4 w-4 ${loadingMode === 'full' ? 'animate-spin' : ''}`} />
+          重新生成
+        </button>
+      </div>
       {error ? <p className="text-xs text-rose-600">{error}</p> : null}
     </div>
   );

--- a/src/lib/appstore/cache.ts
+++ b/src/lib/appstore/cache.ts
@@ -50,6 +50,7 @@ export interface CachedAppReviewPage {
   source: AppResolution['source'];
   stats: ReviewStats;
   reviews: AppStoreReview[];
+  allReviews?: AppStoreReview[];
   sourceBreakdown?: ReviewSourceBreakdown;
   diagnostics?: ReviewDiagnostics;
   insights: ReviewMiningResponse | null;
@@ -83,6 +84,7 @@ interface GenerateCachedReviewOptions {
   maxReviews?: number;
   analyze?: boolean;
   force?: boolean;
+  incremental?: boolean;
 }
 
 interface GenerateCachedReviewResult {
@@ -277,23 +279,53 @@ function hydrateReviewSource(review: AppStoreReview, primaryCountry: string): Ap
 function hydrateCachedReviewPage(page: CachedAppReviewPage): CachedAppReviewPage {
   const primaryCountry = page.app?.country || 'us';
   const reviews = (page.reviews || []).map((review) => hydrateReviewSource(review, primaryCountry));
+  const allReviews = page.allReviews?.map((review) => hydrateReviewSource(review, primaryCountry));
 
   if (page.sourceBreakdown) {
     return {
       ...page,
       reviews,
+      allReviews,
     };
   }
+
+  const trackedReviews = allReviews?.length ? allReviews : reviews;
 
   return {
     ...page,
     reviews,
+    allReviews,
     sourceBreakdown: buildLegacyEstimatedSourceBreakdown(
       page,
-      buildReviewSourceBreakdown(reviews, primaryCountry),
+      buildReviewSourceBreakdown(trackedReviews, primaryCountry),
       primaryCountry
     ),
   };
+}
+
+function isOfficialCacheFile(file: string) {
+  return /^[a-z]{2}-\d+\.json$/i.test(file);
+}
+
+function sortReviewsByDateDesc(reviews: AppStoreReview[]) {
+  return [...reviews].sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime());
+}
+
+function mergeReviewCorpus(newReviews: AppStoreReview[], existingReviews: AppStoreReview[], maxReviews: number) {
+  const seen = new Set<string>();
+  const merged: AppStoreReview[] = [];
+
+  for (const review of [...newReviews, ...existingReviews]) {
+    if (seen.has(review.id)) continue;
+    seen.add(review.id);
+    merged.push(review);
+  }
+
+  return sortReviewsByDateDesc(merged).slice(0, maxReviews);
+}
+
+function getReviewCorpus(page: CachedAppReviewPage) {
+  return page.allReviews?.length ? page.allReviews : page.reviews;
 }
 
 function safeErrorMessage(error: unknown) {
@@ -344,7 +376,7 @@ export async function listCachedReviewPages(): Promise<CachedAppReviewPage[]> {
     const files = await fs.readdir(cacheRoot());
     const pages = await Promise.all(
       files
-        .filter((file) => file.endsWith('.json'))
+        .filter(isOfficialCacheFile)
         .map(async (file) => {
           try {
             const content = await fs.readFile(path.join(cacheRoot(), file), 'utf8');
@@ -363,14 +395,18 @@ export async function listCachedReviewPages(): Promise<CachedAppReviewPage[]> {
 }
 
 export async function getFeaturedCachedApps(limit = 18): Promise<FeaturedAppSummary[]> {
+  const apps = await getCachedAppSummaries();
+  return Number.isFinite(limit) ? apps.slice(0, limit) : apps;
+}
+
+export async function getCachedAppSummaries(): Promise<FeaturedAppSummary[]> {
   const pages = await listCachedReviewPages();
   return pages
     .sort((a, b) => {
-      const ratingDelta = (b.app.userRatingCount || 0) - (a.app.userRatingCount || 0);
-      if (ratingDelta !== 0) return ratingDelta;
-      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      const updatedDelta = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      if (updatedDelta !== 0) return updatedDelta;
+      return (b.app.userRatingCount || 0) - (a.app.userRatingCount || 0);
     })
-    .slice(0, limit)
     .map((page) => ({
       id: page.app.id,
       name: page.app.name,
@@ -395,18 +431,38 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
 
   const needsMoreReviews = existing ? maxReviews > existing.maxReviews : false;
   const needsAnalysis = existing ? options.analyze !== false && (!hasMeaningfulInsights(existing.insights) || Boolean(existing.aiError)) : false;
+  const wantsIncremental = Boolean(options.incremental && existing);
 
-  if (existing && !options.force && !needsMoreReviews && !needsAnalysis) {
+  if (existing && !options.force && !needsMoreReviews && !needsAnalysis && !wantsIncremental) {
     return { page: existing, cached: true };
   }
 
-  const reviews = await AppStoreFetcher.fetchReviews({
-    appId: resolution.app.id,
-    country,
-    incremental: false,
-    maxPages: pageCountForLimit(maxReviews),
-    maxReviews,
-  });
+  let reviews: AppStoreReview[];
+
+  if (existing && wantsIncremental) {
+    const newReviews = await AppStoreFetcher.fetchReviews({
+      appId: resolution.app.id,
+      country,
+      incremental: true,
+      lastFetched: existing.stats.latestReviewDate,
+      maxPages: 3,
+      maxReviews: Math.min(maxReviews, 150),
+    });
+
+    if (newReviews.length === 0 && !needsAnalysis) {
+      return { page: existing, cached: true };
+    }
+
+    reviews = mergeReviewCorpus(newReviews, getReviewCorpus(existing), maxReviews);
+  } else {
+    reviews = await AppStoreFetcher.fetchReviews({
+      appId: resolution.app.id,
+      country,
+      incremental: false,
+      maxPages: pageCountForLimit(maxReviews),
+      maxReviews,
+    });
+  }
 
   if (existing && existing.stats.totalReviews > 0 && reviews.length < existing.stats.totalReviews) {
     console.warn('Skipping cache overwrite because App Store returned fewer reviews for an existing cached page', {
@@ -434,9 +490,10 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
     throw new Error(`App Store 暂时没有返回 ${resolution.app.name} 的评论正文，但该应用有 ${resolution.app.userRatingCount} 个评分。请稍后重新生成。`);
   }
 
-  const sortedReviews = sortReviewsForAnalysis(reviews);
-  const stats = summarizeReviews(reviews);
-  const sourceBreakdown = buildReviewSourceBreakdown(reviews, country);
+  const allReviews = sortReviewsByDateDesc(reviews).slice(0, maxReviews);
+  const sortedReviews = sortReviewsForAnalysis(allReviews);
+  const stats = summarizeReviews(allReviews);
+  const sourceBreakdown = buildReviewSourceBreakdown(allReviews, country);
   let insights: ReviewMiningResponse | null = null;
   let aiError: string | undefined;
   let model: CachedModelInfo | undefined;
@@ -476,6 +533,7 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
     source: resolution.source,
     stats,
     reviews: sortedReviews.slice(0, Math.min(maxReviews, 80)),
+    allReviews,
     sourceBreakdown,
     diagnostics: buildReviewDiagnostics(reviews),
     insights,


### PR DESCRIPTION
## Summary
- Show all formal cached App insight pages on the homepage with pagination
- Filter cache listings to official `{country}-{appId}.json` files so backup `.bad/.partial` files do not appear
- Store full review corpus in new cache writes while keeping detail/API evidence samples small
- Add incremental regenerate support and expose an 增量更新 button on detail pages

## Verification
- npx eslint src/app/page.tsx src/components/app-review/home-client.tsx src/components/app-review/regenerate-button.tsx src/app/api/research/regenerate/route.ts src/lib/appstore/cache.ts
- npm run build in the source deployment repo
- npm run build in this publish repo
- Live homepage shows 28 formal cached apps, page 2/3 with cachePage links
- Live flomo detail page shows 增量更新
- Live incremental regenerate API returns incremental: true
