### PR TITLE
Add App Store Top Charts baseline

### DIFF
--- a/scripts/precache-top-apps.mjs
+++ b/scripts/precache-top-apps.mjs
@@ -5,11 +5,38 @@ const chartMap = {
   paid: 'toppaidapplications',
 };
 
+const categoryMap = {
+  all: '',
+  games: '6014',
+  productivity: '6007',
+  social: '6005',
+  entertainment: '6016',
+  shopping: '6024',
+  photo: '6008',
+  finance: '6015',
+  lifestyle: '6012',
+  education: '6017',
+  utilities: '6002',
+  music: '6011',
+  food: '6023',
+  health: '6013',
+  travel: '6003',
+  news: '6009',
+  sports: '6004',
+  business: '6000',
+  weather: '6001',
+  navigation: '6010',
+  reference: '6006',
+  medical: '6020',
+  books: '6018',
+};
+
 function parseArgs(argv) {
   const options = {
     baseUrl: process.env.APP_REVIEW_BASE_URL || 'http://localhost:3000',
     countries: ['cn', 'us'],
     charts: ['free', 'paid'],
+    categories: ['all'],
     limit: 5,
     maxReviews: 160,
     analyze: true,
@@ -28,6 +55,9 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg === '--charts' && next) {
       options.charts = next.split(',').map((item) => item.trim().toLowerCase()).filter((item) => chartMap[item]);
+      index += 1;
+    } else if (arg === '--categories' && next) {
+      options.categories = next.split(',').map((item) => item.trim().toLowerCase()).filter((item) => Object.prototype.hasOwnProperty.call(categoryMap, item));
       index += 1;
     } else if (arg === '--limit' && next) {
       options.limit = Math.min(Math.max(Number.parseInt(next, 10) || options.limit, 1), 25);
@@ -48,7 +78,7 @@ function parseArgs(argv) {
   };
 }
 
-function normalizeTopEntry(entry, country, chart) {
+function normalizeTopEntry(entry, country, chart, category) {
   const id = entry?.id?.attributes?.['im:id'];
   const name = entry?.['im:name']?.label;
   if (!id || !name) return null;
@@ -58,12 +88,15 @@ function normalizeTopEntry(entry, country, chart) {
     name,
     country,
     chart,
+    category,
   };
 }
 
-async function fetchTopApps(country, chart, limit) {
+async function fetchTopApps(country, chart, category, limit) {
   const rssName = chartMap[chart];
-  const url = `https://itunes.apple.com/${country}/rss/${rssName}/limit=${limit}/json`;
+  const genre = categoryMap[category];
+  const genrePart = genre ? `/genre=${genre}` : '';
+  const url = `https://itunes.apple.com/${country}/rss/${rssName}/limit=${limit}${genrePart}/json`;
   const response = await fetch(url, {
     headers: {
       Accept: 'application/json',
@@ -79,7 +112,7 @@ async function fetchTopApps(country, chart, limit) {
   const rawEntries = data?.feed?.entry;
   const entries = Array.isArray(rawEntries) ? rawEntries : rawEntries ? [rawEntries] : [];
   return entries
-    .map((entry) => normalizeTopEntry(entry, country, chart))
+    .map((entry) => normalizeTopEntry(entry, country, chart, category))
     .filter(Boolean);
 }
 
@@ -111,12 +144,14 @@ async function main() {
 
   for (const country of options.countries) {
     for (const chart of options.charts) {
-      const apps = await fetchTopApps(country, chart, options.limit);
-      for (const app of apps) {
-        const key = `${app.country}-${app.id}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        targets.push(app);
+      for (const category of options.categories) {
+        const apps = await fetchTopApps(country, chart, category, options.limit);
+        for (const app of apps) {
+          const key = `${app.country}-${app.id}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          targets.push(app);
+        }
       }
     }
   }
@@ -125,7 +160,7 @@ async function main() {
 
   const results = [];
   for (const [index, app] of targets.entries()) {
-    const prefix = `[${index + 1}/${targets.length}] ${app.country.toUpperCase()} ${app.chart} ${app.name}`;
+    const prefix = `[${index + 1}/${targets.length}] ${app.country.toUpperCase()} ${app.chart}/${app.category} ${app.name}`;
     try {
       const data = await generateApp(options.baseUrl, app, options);
       console.log(`${prefix} -> ${data.pageUrl} ${data.cached ? '(cached)' : '(generated)'}`);

--- a/src/app/api/top-charts/route.ts
+++ b/src/app/api/top-charts/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchTopChartApps } from '@/lib/appstore/top-charts';
+import { ApiResponse } from '@/types';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function safeErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : '榜单获取失败';
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const apps = await fetchTopChartApps({
+      country: searchParams.get('country') || undefined,
+      chart: searchParams.get('chart') || undefined,
+      category: searchParams.get('category') || undefined,
+      limit: 10,
+    });
+
+    return NextResponse.json<ApiResponse<typeof apps>>({
+      success: true,
+      data: apps,
+    });
+  } catch (error) {
+    console.error('Top charts request failed:', error);
+    return NextResponse.json<ApiResponse>(
+      {
+        success: false,
+        error: safeErrorMessage(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from 'next';
 import AppReviewHome from '@/components/app-review/home-client';
 import { getCachedAppSummaries } from '@/lib/appstore/cache';
+import {
+  TOP_CHART_CATEGORIES,
+  TOP_CHART_COUNTRIES,
+  fetchTopChartApps,
+} from '@/lib/appstore/top-charts';
 
 export const dynamic = 'force-dynamic';
 
@@ -45,6 +50,23 @@ export default async function Page({ searchParams }: PageProps) {
   const params = await searchParams;
   const featuredApps = await getCachedAppSummaries();
   const initialCachePage = parseCachePage(params?.cachePage);
+  const initialTopChartApps = await fetchTopChartApps({
+    country: 'cn',
+    chart: 'free',
+    category: 'all',
+    limit: 10,
+  }).catch((error) => {
+    console.error('Failed to load initial top charts:', error);
+    return [];
+  });
 
-  return <AppReviewHome featuredApps={featuredApps} initialCachePage={initialCachePage} />;
+  return (
+    <AppReviewHome
+      featuredApps={featuredApps}
+      initialCachePage={initialCachePage}
+      topChartCountries={TOP_CHART_COUNTRIES}
+      topChartCategories={TOP_CHART_CATEGORIES}
+      initialTopChartApps={initialTopChartApps}
+    />
+  );
 }

--- a/src/components/app-review/home-client.tsx
+++ b/src/components/app-review/home-client.tsx
@@ -22,6 +22,7 @@ import {
   ReviewSourceBreakdownPanel,
   reviewSourceLabel,
 } from '@/components/app-review/source-breakdown';
+import { TopChartsSection } from '@/components/app-review/top-charts-section';
 import { AppStoreReview } from '@/types';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -104,6 +105,38 @@ interface FeaturedAppSummary {
   negativeShare: number;
   positiveShare: number;
   primaryGenreName?: string;
+}
+
+interface TopChartCountry {
+  value: string;
+  label: string;
+}
+
+interface TopChartCategory {
+  value: string;
+  label: string;
+  genre?: string;
+}
+
+interface TopChartApp {
+  rank: number;
+  id: string;
+  name: string;
+  artistName: string;
+  artworkUrl: string;
+  categoryName?: string;
+  appStoreUrl?: string;
+  country: string;
+  chart: 'free' | 'paid';
+  category: string;
+  cached?: {
+    pagePath: string;
+    updatedAt: string;
+    totalReviews: number;
+    averageRating: number;
+    negativeShare: number;
+    hasInsights: boolean;
+  };
 }
 
 interface ApiResponse<T> {
@@ -312,9 +345,15 @@ function FeaturedApps({ apps, currentPage }: { apps: FeaturedAppSummary[]; curre
 export default function Home({
   featuredApps = [],
   initialCachePage = 1,
+  topChartCountries = [],
+  topChartCategories = [],
+  initialTopChartApps = [],
 }: {
   featuredApps?: FeaturedAppSummary[];
   initialCachePage?: number;
+  topChartCountries?: TopChartCountry[];
+  topChartCategories?: TopChartCategory[];
+  initialTopChartApps?: TopChartApp[];
 }) {
   const [query, setQuery] = useState('ChatGPT');
   const [country, setCountry] = useState('cn');
@@ -670,6 +709,11 @@ export default function Home({
         </section>
       ) : (
         <>
+          <TopChartsSection
+            countries={topChartCountries}
+            categories={topChartCategories}
+            initialApps={initialTopChartApps}
+          />
           <FeaturedApps apps={featuredApps} currentPage={initialCachePage} />
           <section className="mx-auto grid max-w-7xl gap-4 px-4 py-6 sm:px-6 lg:grid-cols-3 lg:px-8">
             <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">

--- a/src/components/app-review/top-charts-section.tsx
+++ b/src/components/app-review/top-charts-section.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { ArrowUpRight, Bot, ChevronsUpDown, Loader2, RefreshCw, Trophy } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+type TopChartType = 'free' | 'paid';
+
+interface TopChartCountry {
+  value: string;
+  label: string;
+}
+
+interface TopChartCategory {
+  value: string;
+  label: string;
+  genre?: string;
+}
+
+interface TopChartApp {
+  rank: number;
+  id: string;
+  name: string;
+  artistName: string;
+  artworkUrl: string;
+  categoryName?: string;
+  appStoreUrl?: string;
+  country: string;
+  chart: TopChartType;
+  category: string;
+  cached?: {
+    pagePath: string;
+    updatedAt: string;
+    totalReviews: number;
+    averageRating: number;
+    negativeShare: number;
+    hasInsights: boolean;
+  };
+}
+
+interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+interface TopChartsSectionProps {
+  countries: TopChartCountry[];
+  categories: TopChartCategory[];
+  initialApps: TopChartApp[];
+}
+
+function formatPercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
+function chartLabel(chart: TopChartType) {
+  return chart === 'paid' ? '付费榜' : '免费榜';
+}
+
+function optionLabel<T extends { value: string; label: string }>(options: T[], value: string) {
+  return options.find((option) => option.value === value)?.label || value.toUpperCase();
+}
+
+export function TopChartsSection({ countries, categories, initialApps }: TopChartsSectionProps) {
+  const [country, setCountry] = useState('cn');
+  const [category, setCategory] = useState('all');
+  const [chart, setChart] = useState<TopChartType>('free');
+  const [apps, setApps] = useState<TopChartApp[]>(initialApps);
+  const [loading, setLoading] = useState(false);
+  const [generatingId, setGeneratingId] = useState('');
+  const [batchGenerating, setBatchGenerating] = useState(false);
+  const [error, setError] = useState('');
+
+  const title = useMemo(
+    () => `${optionLabel(countries, country)} · ${optionLabel(categories, category)} · ${chartLabel(chart)} Top 10`,
+    [categories, category, chart, countries, country]
+  );
+
+  const fetchChart = async (next = { country, category, chart }) => {
+    setLoading(true);
+    setError('');
+
+    try {
+      const params = new URLSearchParams({
+        country: next.country,
+        category: next.category,
+        chart: next.chart,
+      });
+      const response = await fetch(`/api/top-charts?${params.toString()}`);
+      const payload = await response.json() as ApiResponse<TopChartApp[]>;
+
+      if (!response.ok || !payload.success || !payload.data) {
+        throw new Error(payload.error || '榜单获取失败');
+      }
+
+      setApps(payload.data);
+    } catch (chartError) {
+      setError(chartError instanceof Error ? chartError.message : '榜单获取失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateFilter = async (next: Partial<{ country: string; category: string; chart: TopChartType }>) => {
+    const merged = {
+      country: next.country || country,
+      category: next.category || category,
+      chart: next.chart || chart,
+    };
+    if (next.country) setCountry(next.country);
+    if (next.category) setCategory(next.category);
+    if (next.chart) setChart(next.chart);
+    await fetchChart(merged);
+  };
+
+  const generateInsight = async (app: TopChartApp) => {
+    setGeneratingId(app.id);
+    setError('');
+
+    try {
+      const response = await fetch('/api/research', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: app.id,
+          country: app.country,
+          maxReviews: 160,
+          analyze: true,
+        }),
+      });
+      const payload = await response.json() as ApiResponse<{
+        pageUrl: string;
+        updatedAt: string;
+        stats: {
+          totalReviews: number;
+          averageRating: number;
+          negativeShare: number;
+        };
+        insights: unknown;
+      }>;
+
+      if (!response.ok || !payload.success || !payload.data) {
+        throw new Error(payload.error || '生成洞察失败');
+      }
+
+      setApps((items) => items.map((item) => item.id === app.id ? {
+        ...item,
+        cached: {
+          pagePath: payload.data!.pageUrl,
+          updatedAt: payload.data!.updatedAt,
+          totalReviews: payload.data!.stats.totalReviews,
+          averageRating: payload.data!.stats.averageRating,
+          negativeShare: payload.data!.stats.negativeShare,
+          hasInsights: Boolean(payload.data!.insights),
+        },
+      } : item));
+    } catch (generateError) {
+      setError(generateError instanceof Error ? generateError.message : '生成洞察失败');
+    } finally {
+      setGeneratingId('');
+    }
+  };
+
+  const generateTop10 = async () => {
+    setBatchGenerating(true);
+    for (const app of apps) {
+      if (!app.cached) {
+        await generateInsight(app);
+      }
+    }
+    setBatchGenerating(false);
+  };
+
+  return (
+    <section className="mx-auto max-w-7xl px-4 pt-6 sm:px-6 lg:px-8">
+      <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-teal-700">
+              <Trophy className="h-4 w-4" />
+              App Store Top Charts
+            </div>
+            <h2 className="mt-2 text-xl font-semibold text-zinc-950">{title}</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-zinc-500">
+              从 Apple 榜单选出基础 App 池，已生成的直接查看 DeepSeek 洞察，未生成的可一键生成缓存页。
+            </p>
+          </div>
+          <Button
+            type="button"
+            onClick={generateTop10}
+            disabled={batchGenerating || loading || apps.length === 0}
+            className="rounded-md bg-zinc-950 text-white hover:bg-zinc-800"
+          >
+            {batchGenerating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Bot className="mr-2 h-4 w-4" />}
+            生成本榜 Top10
+          </Button>
+        </div>
+
+        <div className="mt-4 grid gap-3 md:grid-cols-[150px_minmax(0,1fr)_130px_44px]">
+          <div className="relative">
+            <select
+              value={country}
+              onChange={(event) => updateFilter({ country: event.target.value })}
+              className="h-10 w-full appearance-none rounded-md border border-zinc-200 bg-zinc-50 px-3 pr-8 text-sm outline-none transition focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900/10"
+              aria-label="Top chart country"
+            >
+              {countries.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+            <ChevronsUpDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+          </div>
+          <div className="relative">
+            <select
+              value={category}
+              onChange={(event) => updateFilter({ category: event.target.value })}
+              className="h-10 w-full appearance-none rounded-md border border-zinc-200 bg-zinc-50 px-3 pr-8 text-sm outline-none transition focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900/10"
+              aria-label="Top chart category"
+            >
+              {categories.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+            <ChevronsUpDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+          </div>
+          <div className="relative">
+            <select
+              value={chart}
+              onChange={(event) => updateFilter({ chart: event.target.value as TopChartType })}
+              className="h-10 w-full appearance-none rounded-md border border-zinc-200 bg-zinc-50 px-3 pr-8 text-sm outline-none transition focus:border-zinc-900 focus:ring-2 focus:ring-zinc-900/10"
+              aria-label="Top chart type"
+            >
+              <option value="free">免费榜</option>
+              <option value="paid">付费榜</option>
+            </select>
+            <ChevronsUpDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" />
+          </div>
+          <Button type="button" size="icon" onClick={() => fetchChart()} disabled={loading} className="h-10 w-full rounded-md bg-zinc-950 hover:bg-zinc-800 md:w-10">
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          </Button>
+        </div>
+
+        {error ? (
+          <div className="mt-3 rounded-md border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-4 divide-y divide-zinc-100 overflow-hidden rounded-lg border border-zinc-100">
+          {apps.map((app) => (
+            <div key={`${app.country}-${app.chart}-${app.category}-${app.id}`} className="grid gap-3 bg-white p-3 md:grid-cols-[42px_minmax(0,1fr)_220px] md:items-center">
+              <div className="text-center text-lg font-semibold text-zinc-400">#{app.rank}</div>
+              <div className="flex min-w-0 gap-3">
+                {app.artworkUrl ? (
+                  <img src={app.artworkUrl} alt={`${app.name} icon`} className="h-12 w-12 shrink-0 rounded-lg border border-zinc-200 bg-white object-cover" />
+                ) : (
+                  <div className="h-12 w-12 shrink-0 rounded-lg bg-zinc-100" />
+                )}
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-semibold text-zinc-950">{app.name}</h3>
+                  <p className="mt-1 truncate text-xs text-zinc-500">{app.artistName}</p>
+                  <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-zinc-500">
+                    <span className="rounded-md bg-zinc-100 px-2 py-0.5">{app.country.toUpperCase()}</span>
+                    <span className="rounded-md bg-zinc-100 px-2 py-0.5">{app.categoryName || optionLabel(categories, app.category)}</span>
+                    <span className="rounded-md bg-zinc-100 px-2 py-0.5">{chartLabel(app.chart)}</span>
+                  </div>
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 md:justify-end">
+                {app.cached ? (
+                  <>
+                    <span className="rounded-md bg-amber-50 px-2 py-1 text-xs text-amber-700">{app.cached.averageRating || 0} 星</span>
+                    <span className="rounded-md bg-zinc-50 px-2 py-1 text-xs text-zinc-600">{app.cached.totalReviews} 条</span>
+                    <span className="rounded-md bg-rose-50 px-2 py-1 text-xs text-rose-700">{formatPercent(app.cached.negativeShare)}</span>
+                    <a href={app.cached.pagePath} className="inline-flex items-center gap-1 rounded-md bg-zinc-950 px-3 py-2 text-sm text-white transition hover:bg-zinc-800">
+                      查看洞察
+                      <ArrowUpRight className="h-3.5 w-3.5" />
+                    </a>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => generateInsight(app)}
+                    disabled={Boolean(generatingId) || batchGenerating}
+                    className="inline-flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-700 transition hover:border-zinc-300 hover:text-zinc-950 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {generatingId === app.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Bot className="h-3.5 w-3.5" />}
+                    生成洞察
+                  </button>
+                )}
+                {app.appStoreUrl ? (
+                  <a href={app.appStoreUrl} target="_blank" rel="noreferrer" className="inline-flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-950">
+                    App Store
+                    <ArrowUpRight className="h-3.5 w-3.5" />
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/appstore/cache.ts
+++ b/src/lib/appstore/cache.ts
@@ -328,6 +328,23 @@ function getReviewCorpus(page: CachedAppReviewPage) {
   return page.allReviews?.length ? page.allReviews : page.reviews;
 }
 
+function cacheIdentity(page: CachedAppReviewPage) {
+  return `${normalizeCountry(page.app?.country || 'us')}-${page.app?.id || page.cacheKey}`;
+}
+
+function pickBetterCachedPage(current: CachedAppReviewPage, candidate: CachedAppReviewPage) {
+  const currentReviews = current.stats?.totalReviews || 0;
+  const candidateReviews = candidate.stats?.totalReviews || 0;
+
+  if (candidateReviews !== currentReviews) {
+    return candidateReviews > currentReviews ? candidate : current;
+  }
+
+  return new Date(candidate.updatedAt).getTime() > new Date(current.updatedAt).getTime()
+    ? candidate
+    : current;
+}
+
 function safeErrorMessage(error: unknown) {
   if (!(error instanceof Error)) return '未知错误';
   if (/api[_-]?key|authorization|secret|token/i.test(error.message)) {
@@ -401,7 +418,16 @@ export async function getFeaturedCachedApps(limit = 18): Promise<FeaturedAppSumm
 
 export async function getCachedAppSummaries(): Promise<FeaturedAppSummary[]> {
   const pages = await listCachedReviewPages();
-  return pages
+  const dedupedPages = Array.from(
+    pages.reduce((map, page) => {
+      const key = cacheIdentity(page);
+      const current = map.get(key);
+      map.set(key, current ? pickBetterCachedPage(current, page) : page);
+      return map;
+    }, new Map<string, CachedAppReviewPage>()).values()
+  );
+
+  return dedupedPages
     .sort((a, b) => {
       const updatedDelta = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
       if (updatedDelta !== 0) return updatedDelta;

--- a/src/lib/appstore/top-charts.ts
+++ b/src/lib/appstore/top-charts.ts
@@ -1,0 +1,192 @@
+import 'server-only';
+
+import { readCachedReviewPage } from '@/lib/appstore/cache';
+import { normalizeCountry } from '@/lib/appstore/discovery';
+
+export type TopChartType = 'free' | 'paid';
+
+export interface TopChartCountry {
+  value: string;
+  label: string;
+}
+
+export interface TopChartCategory {
+  value: string;
+  label: string;
+  genre?: string;
+}
+
+export interface TopChartApp {
+  rank: number;
+  id: string;
+  name: string;
+  artistName: string;
+  artworkUrl: string;
+  categoryName?: string;
+  appStoreUrl?: string;
+  country: string;
+  chart: TopChartType;
+  category: string;
+  cached?: {
+    pagePath: string;
+    updatedAt: string;
+    totalReviews: number;
+    averageRating: number;
+    negativeShare: number;
+    hasInsights: boolean;
+  };
+}
+
+interface AppleTopChartEntry {
+  id?: {
+    label?: string;
+    attributes?: {
+      'im:id'?: string;
+    };
+  };
+  'im:name'?: { label?: string };
+  'im:artist'?: { label?: string };
+  'im:image'?: Array<{ label?: string }>;
+  category?: {
+    attributes?: {
+      label?: string;
+    };
+  };
+  link?: {
+    attributes?: {
+      href?: string;
+    };
+  };
+}
+
+const CHART_FEEDS: Record<TopChartType, string> = {
+  free: 'topfreeapplications',
+  paid: 'toppaidapplications',
+};
+
+export const TOP_CHART_COUNTRIES: TopChartCountry[] = [
+  { value: 'cn', label: '中国' },
+  { value: 'us', label: '美国' },
+  { value: 'jp', label: '日本' },
+  { value: 'gb', label: '英国' },
+  { value: 'de', label: '德国' },
+  { value: 'fr', label: '法国' },
+  { value: 'kr', label: '韩国' },
+  { value: 'hk', label: '香港' },
+  { value: 'tw', label: '台湾' },
+  { value: 'sg', label: '新加坡' },
+  { value: 'ca', label: '加拿大' },
+  { value: 'au', label: '澳大利亚' },
+];
+
+export const TOP_CHART_CATEGORIES: TopChartCategory[] = [
+  { value: 'all', label: '全部 App' },
+  { value: 'games', label: '游戏', genre: '6014' },
+  { value: 'productivity', label: '效率', genre: '6007' },
+  { value: 'social-networking', label: '社交', genre: '6005' },
+  { value: 'entertainment', label: '娱乐', genre: '6016' },
+  { value: 'shopping', label: '购物', genre: '6024' },
+  { value: 'photo-video', label: '摄影与录像', genre: '6008' },
+  { value: 'finance', label: '财务', genre: '6015' },
+  { value: 'lifestyle', label: '生活', genre: '6012' },
+  { value: 'education', label: '教育', genre: '6017' },
+  { value: 'utilities', label: '工具', genre: '6002' },
+  { value: 'music', label: '音乐', genre: '6011' },
+  { value: 'food-drink', label: '美食佳饮', genre: '6023' },
+  { value: 'health-fitness', label: '健康健美', genre: '6013' },
+  { value: 'travel', label: '旅游', genre: '6003' },
+  { value: 'news', label: '新闻', genre: '6009' },
+  { value: 'sports', label: '体育', genre: '6004' },
+  { value: 'business', label: '商务', genre: '6000' },
+  { value: 'weather', label: '天气', genre: '6001' },
+  { value: 'navigation', label: '导航', genre: '6010' },
+  { value: 'reference', label: '参考', genre: '6006' },
+  { value: 'medical', label: '医疗', genre: '6020' },
+  { value: 'books', label: '图书', genre: '6018' },
+  { value: 'magazines', label: '报刊杂志', genre: '6021' },
+  { value: 'graphics-design', label: '图形与设计', genre: '6027' },
+  { value: 'developer-tools', label: '开发工具', genre: '6026' },
+];
+
+export function normalizeTopChartType(value?: string): TopChartType {
+  return value === 'paid' ? 'paid' : 'free';
+}
+
+export function normalizeTopChartCategory(value?: string): TopChartCategory {
+  return TOP_CHART_CATEGORIES.find((category) => category.value === value) || TOP_CHART_CATEGORIES[0];
+}
+
+function topChartUrl(country: string, chart: TopChartType, category: TopChartCategory, limit: number) {
+  const feed = CHART_FEEDS[chart];
+  const genrePart = category.genre ? `/genre=${category.genre}` : '';
+  return `https://itunes.apple.com/${country}/rss/${feed}/limit=${limit}${genrePart}/json`;
+}
+
+function normalizeEntry(entry: AppleTopChartEntry, index: number, country: string, chart: TopChartType, category: string): TopChartApp | null {
+  const id = entry.id?.attributes?.['im:id'];
+  const name = entry['im:name']?.label;
+
+  if (!id || !name) return null;
+
+  return {
+    rank: index + 1,
+    id,
+    name,
+    artistName: entry['im:artist']?.label || 'App Store',
+    artworkUrl: entry['im:image']?.at(-1)?.label || '',
+    categoryName: entry.category?.attributes?.label,
+    appStoreUrl: entry.link?.attributes?.href,
+    country,
+    chart,
+    category,
+  };
+}
+
+export async function fetchTopChartApps(options: {
+  country?: string;
+  chart?: string;
+  category?: string;
+  limit?: number;
+}): Promise<TopChartApp[]> {
+  const country = normalizeCountry(options.country);
+  const chart = normalizeTopChartType(options.chart);
+  const category = normalizeTopChartCategory(options.category);
+  const limit = Math.min(Math.max(Math.trunc(options.limit || 10), 1), 10);
+  const response = await fetch(topChartUrl(country, chart, category, limit), {
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': 'QiaomuAppReviewTopCharts/1.0',
+    },
+    next: { revalidate: 3600 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Apple Top Charts ${country}/${chart}/${category.value} 返回 HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+  const rawEntries = data?.feed?.entry;
+  const entries = Array.isArray(rawEntries) ? rawEntries : rawEntries ? [rawEntries] : [];
+  const apps = entries
+    .map((entry: AppleTopChartEntry, index: number) => normalizeEntry(entry, index, country, chart, category.value))
+    .filter((app: TopChartApp | null): app is TopChartApp => Boolean(app));
+
+  return Promise.all(
+    apps.map(async (app) => {
+      const cached = await readCachedReviewPage(app.country, app.id);
+      if (!cached) return app;
+
+      return {
+        ...app,
+        cached: {
+          pagePath: cached.pagePath,
+          updatedAt: cached.updatedAt,
+          totalReviews: cached.stats.totalReviews,
+          averageRating: cached.stats.averageRating,
+          negativeShare: cached.stats.negativeShare,
+          hasInsights: Boolean(cached.insights),
+        },
+      };
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- dedupe cached homepage summaries by country + App ID so backup/partial cache artifacts cannot create duplicate cards
- add an App Store Top Charts data layer and /api/top-charts for country, category, and free/paid Top10 lists
- add a homepage Top Charts section with cached insight status, single-app generation, and generate-current-Top10 action
- extend the precache script with --categories so baseline pages can be generated by country/category

## Verification
- npx eslint src/app/page.tsx src/app/api/top-charts/route.ts src/lib/appstore/top-charts.ts src/lib/appstore/cache.ts src/components/app-review/home-client.tsx src/components/app-review/top-charts-section.tsx scripts/precache-top-apps.mjs
- npm run build
- live https://appreview.qiaomu.ai/api/health returns deepseek-v4-flash
- live homepage contains App Store Top Charts and only one 1044283059 occurrence
- live /api/top-charts?country=us&category=productivity&chart=free returns ChatGPT in the Top10
- live /api/top-charts?country=cn&category=games&chart=paid returns 潜水员戴夫 in the Top10

## Notes
- npx tsc --noEmit still fails on pre-existing repository type debt around older dynamic route params, prompt storage methods, and legacy review components; Next build succeeds with the project configuration.