### PR TITLE
Fix Top Charts App Store links

### DIFF
--- a/src/lib/appstore/top-charts.ts
+++ b/src/lib/appstore/top-charts.ts
@@ -52,11 +52,25 @@ interface AppleTopChartEntry {
       label?: string;
     };
   };
-  link?: {
-    attributes?: {
-      href?: string;
-    };
+  link?: AppleTopChartLink | AppleTopChartLink[];
+}
+
+interface AppleTopChartLink {
+  attributes?: {
+    href?: string;
+    rel?: string;
+    type?: string;
   };
+}
+
+function getEntryAppStoreUrl(entry: AppleTopChartEntry, country: string, id: string) {
+  const links = Array.isArray(entry.link) ? entry.link : entry.link ? [entry.link] : [];
+  const appStoreLink = links.find((link) => {
+    const attributes = link.attributes;
+    return attributes?.href && attributes.rel === 'alternate' && attributes.type === 'text/html';
+  }) || links.find((link) => link.attributes?.href?.includes('/app/'));
+
+  return appStoreLink?.attributes?.href || `https://apps.apple.com/${country}/app/id${id}`;
 }
 
 const CHART_FEEDS: Record<TopChartType, string> = {
@@ -135,7 +149,7 @@ function normalizeEntry(entry: AppleTopChartEntry, index: number, country: strin
     artistName: entry['im:artist']?.label || 'App Store',
     artworkUrl: entry['im:image']?.at(-1)?.label || '',
     categoryName: entry.category?.attributes?.label,
-    appStoreUrl: entry.link?.attributes?.href,
+    appStoreUrl: getEntryAppStoreUrl(entry, country, id),
     country,
     chart,
     category,


### PR DESCRIPTION
## Summary
- handle Apple Top Charts RSS entries where link is either a single object or an array
- pick the rel=alternate text/html link instead of ignoring entries with preview assets
- add an id-only App Store URL fallback so every Top Charts app can expose an App Store address

## Verification
- npx eslint src/lib/appstore/top-charts.ts
- npm run build
- live /api/top-charts?country=us&category=productivity&chart=free returns 10 apps with no missing appStoreUrl
- live /api/top-charts?country=cn&category=games&chart=paid returns 10 apps with no missing appStoreUrl
- live /api/health returns deepseek-v4-flash