### PR TITLE
Remove internal SEO copy from app review pages

### DIFF
--- a/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
+++ b/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
@@ -69,7 +69,7 @@ async function getPage(country: string, appId: string) {
 }
 
 function metadataDescription(page: CachedAppReviewPage) {
-  return `基于 ${page.stats.totalReviews} 条 ${page.app.name} App Store 用户评价，提炼评分趋势、差评痛点、产品机会、版本风险和可引用摘要。更新时间：${formatDate(page.updatedAt)}。`;
+  return `基于 ${page.stats.totalReviews} 条 ${page.app.name} App Store 用户评价，提炼评分趋势、差评痛点、产品机会、版本风险和关键摘要。更新时间：${formatDate(page.updatedAt)}。`;
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
@@ -80,7 +80,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!cached) {
     return {
       title: `App ${appId} 评价洞察`,
-      description: 'App Store 用户评价分析页面，生成后会缓存为可分享的 SEO 洞察页。',
+      description: 'App Store 用户评价分析页面，生成后可查看评价洞察页。',
       alternates: {
         canonical: buildCanonicalUrl(`/apps/${normalizedCountry}/${appId}`),
       },
@@ -99,7 +99,6 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       'App Store评论分析',
       '用户反馈挖掘',
       'DeepSeek flash',
-      'AI搜索摘要',
       '产品需求分析',
     ],
     alternates: {
@@ -168,7 +167,7 @@ export default async function AppInsightPage({ params }: PageProps) {
             <img src="/logo.svg" alt="乔木App评价洞察 Logo" className="h-9 w-9 rounded-lg shadow-sm" />
             <div>
               <p className="text-sm font-semibold text-zinc-950">乔木App评价洞察</p>
-              <p className="text-xs text-zinc-500">SEO App Review Insights</p>
+              <p className="text-xs text-zinc-500">App Review Insights</p>
             </div>
           </Link>
           <Link href="/" className="inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-950">
@@ -209,7 +208,7 @@ export default async function AppInsightPage({ params }: PageProps) {
                 </h1>
                 <p className="mt-2 text-sm text-zinc-500">{page.app.artistName || 'App Store'} · 更新于 {formatDate(page.updatedAt)}</p>
                 <p className="mt-4 max-w-3xl text-base leading-7 text-zinc-700">
-                  本页基于 App Store 用户评价缓存生成，面向产品分析、竞品研究和搜索引用场景，保留评论证据、来源构成和样本边界，并用 DeepSeek flash 提炼可行动信号。
+                  本页基于 App Store 用户评价生成，面向产品分析和竞品研究，保留评论证据、来源构成和样本边界，并用 DeepSeek flash 提炼可行动信号。
                 </p>
               </div>
             </div>
@@ -256,7 +255,7 @@ export default async function AppInsightPage({ params }: PageProps) {
 
       <section className="mx-auto grid max-w-7xl gap-4 px-4 py-6 sm:grid-cols-2 sm:px-6 lg:grid-cols-4 lg:px-8">
         <div className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
-          <p className="text-sm text-zinc-500">缓存评论</p>
+          <p className="text-sm text-zinc-500">评论样本</p>
           <p className="mt-2 text-2xl font-semibold text-zinc-950">{page.stats.totalReviews}</p>
         </div>
         <div className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
@@ -347,18 +346,18 @@ export default async function AppInsightPage({ params }: PageProps) {
         <div className="mx-auto grid max-w-7xl gap-4 px-4 py-6 sm:px-6 lg:grid-cols-3 lg:px-8">
           <div>
             <TrendingDown className="h-5 w-5 text-rose-600" />
-            <h2 className="mt-3 text-base font-semibold text-zinc-950">这个页面如何用于 SEO？</h2>
-            <p className="mt-2 text-sm leading-6 text-zinc-500">稳定 URL、动态 TDK、结构化数据和更新时间让搜索引擎能理解每个 App 的评价主题。</p>
+            <h2 className="mt-3 text-base font-semibold text-zinc-950">这个页面适合团队怎么用？</h2>
+            <p className="mt-2 text-sm leading-6 text-zinc-500">同一个链接里保留摘要、更新时间和评论证据，方便产品、运营和研发对齐同一版结论。</p>
           </div>
           <div>
             <Lightbulb className="h-5 w-5 text-amber-600" />
-            <h2 className="mt-3 text-base font-semibold text-zinc-950">这个页面如何被 AI 搜索引用？</h2>
-            <p className="mt-2 text-sm leading-6 text-zinc-500">页面提供摘要、证据、痛点和行动项，方便生成式搜索直接引用有来源的结论。</p>
+            <h2 className="mt-3 text-base font-semibold text-zinc-950">这些结论可靠吗？</h2>
+            <p className="mt-2 text-sm leading-6 text-zinc-500">页面保留摘要、证据、痛点和行动项，每个判断都尽量回到原始评论样本。</p>
           </div>
           <div>
             <Target className="h-5 w-5 text-teal-600" />
             <h2 className="mt-3 text-base font-semibold text-zinc-950">数据如何更新？</h2>
-            <p className="mt-2 text-sm leading-6 text-zinc-500">页面记录更新时间，可点击重新生成，重新抓取评论并覆盖缓存页面。</p>
+            <p className="mt-2 text-sm leading-6 text-zinc-500">页面记录更新时间，可点击重新生成，抓取最新评论并更新当前洞察页。</p>
           </div>
         </div>
       </section>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     default: "乔木App评价洞察",
     template: "%s | 乔木App评价洞察",
   },
-  description: "搜索任意 iOS App，生成可缓存的 App Store 用户评价洞察页，用 DeepSeek flash 挖掘痛点、机会和版本风险。",
+  description: "搜索任意 iOS App，生成 App Store 用户评价洞察页，用 DeepSeek flash 挖掘痛点、机会和版本风险。",
   applicationName: "乔木App评价洞察",
   icons: {
     icon: "/logo.svg",
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: "乔木App评价洞察",
-    description: "把 App Store 用户评价变成可缓存、可分享、SEO/GEO 友好的产品洞察页面。",
+    description: "把 App Store 用户评价变成清晰、可复盘的产品洞察页面。",
     url: "https://appreview.qiaomu.ai/",
     siteName: "乔木App评价洞察",
     type: "website",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,15 +11,13 @@ export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: '乔木App评价洞察 - App Store用户评价分析与DeepSeek信息挖掘',
-  description: '搜索任意 iOS App，生成可缓存、可分享、SEO 友好的评价洞察页面，用 DeepSeek flash 从 App Store 评论中提炼痛点、机会、版本风险和用户需求。',
+  description: '搜索任意 iOS App，生成用户评价洞察页面，用 DeepSeek flash 从 App Store 评论中提炼痛点、机会、版本风险和用户需求。',
   keywords: [
     '乔木App评价洞察',
     'App评价分析',
     'App Store评论分析',
     '用户反馈挖掘',
     'DeepSeek flash',
-    'GEO',
-    'SEO',
     '产品需求分析',
   ],
   alternates: {
@@ -27,7 +25,7 @@ export const metadata: Metadata = {
   },
   openGraph: {
     title: '乔木App评价洞察',
-    description: '把 App Store 用户评价生成可缓存的 SEO 洞察页面，快速发现产品痛点、机会和版本风险。',
+    description: '把 App Store 用户评价生成产品洞察页面，快速发现产品痛点、机会和版本风险。',
     url: 'https://appreview.qiaomu.ai/',
     siteName: '乔木App评价洞察',
     type: 'website',

--- a/src/components/app-review/home-client.tsx
+++ b/src/components/app-review/home-client.tsx
@@ -5,10 +5,8 @@ import {
   AlertCircle,
   Apple,
   ArrowUpRight,
-  Bot,
   CheckCircle2,
   ChevronsUpDown,
-  Clock3,
   Lightbulb,
   Loader2,
   Search,
@@ -157,13 +155,6 @@ const countryOptions = [
   { value: 'tw', label: '台湾' },
 ];
 
-const exampleQueries = [
-  'ChatGPT',
-  'DeepSeek',
-  '豆包',
-  'https://apps.apple.com/us/app/chatgpt/id6448311069',
-];
-
 const CACHED_APP_PAGE_SIZE = 12;
 
 function formatDate(value?: string) {
@@ -253,7 +244,7 @@ function FeaturedApps({ apps, currentPage }: { apps: FeaturedAppSummary[]; curre
       <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-zinc-950">已生成的 App 洞察页</h2>
-          <p className="mt-1 text-sm text-zinc-500">所有搜索生成过的正式缓存都会出现在这里，按最近更新时间分页展示。</p>
+          <p className="mt-1 text-sm text-zinc-500">所有查询过的 App 都会出现在这里，按最近更新时间分页展示。</p>
         </div>
         <span className="rounded-full border border-zinc-200 bg-white px-3 py-1 text-xs text-zinc-500">
           共 {apps.length} 个 · 第 {page}/{totalPages} 页
@@ -296,7 +287,7 @@ function FeaturedApps({ apps, currentPage }: { apps: FeaturedAppSummary[]; curre
         ))}
       </div>
       {totalPages > 1 ? (
-        <nav className="mt-4 flex flex-wrap items-center justify-center gap-2" aria-label="缓存 App 分页">
+        <nav className="mt-4 flex flex-wrap items-center justify-center gap-2" aria-label="App 分页">
           <a
             href={pageHref(page - 1)}
             className={`rounded-md border px-3 py-2 text-sm transition ${
@@ -358,7 +349,7 @@ export default function Home({
   const [query, setQuery] = useState('ChatGPT');
   const [country, setCountry] = useState('cn');
   const [maxReviews, setMaxReviews] = useState(160);
-  const [analyze, setAnalyze] = useState(true);
+  const analyze = true;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState<ResearchData | null>(null);
@@ -411,13 +402,13 @@ export default function Home({
       </header>
 
       <section className="border-b border-zinc-200 bg-[#fdfdfb]">
-        <div className="mx-auto grid max-w-7xl gap-6 px-4 py-7 sm:px-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:px-8">
+        <div className="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8">
           <div className="min-w-0">
             <h1 className="max-w-4xl text-3xl font-semibold leading-tight text-zinc-950 sm:text-4xl">
               乔木App评价洞察
             </h1>
             <p className="mt-3 max-w-3xl text-base leading-7 text-zinc-600">
-              搜索 App Store 应用，生成可缓存、可分享、SEO 友好的用户评价洞察页，用 DeepSeek flash 提炼痛点、机会、版本风险和可引用摘要。
+              搜索 App Store 应用，生成用户评价洞察页，提炼痛点、机会、版本风险和关键摘要。
             </p>
             <form onSubmit={runResearch} className="mt-6 rounded-lg border border-zinc-200 bg-white p-3 shadow-sm">
               <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_130px_118px_44px]">
@@ -461,30 +452,6 @@ export default function Home({
                   {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
                 </Button>
               </div>
-              <div className="mt-3 flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => setAnalyze((value) => !value)}
-                  className={`inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-xs transition ${
-                    analyze
-                      ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                      : 'border-zinc-200 bg-zinc-50 text-zinc-500'
-                  }`}
-                >
-                  <Bot className="h-3.5 w-3.5" />
-                  DeepSeek flash
-                </button>
-                {exampleQueries.map((item) => (
-                  <button
-                    key={item}
-                    type="button"
-                    onClick={() => setQuery(item)}
-                    className="max-w-full truncate rounded-md border border-zinc-200 bg-white px-3 py-1.5 text-xs text-zinc-500 transition hover:border-zinc-300 hover:text-zinc-900"
-                  >
-                    {item}
-                  </button>
-                ))}
-              </div>
             </form>
             {error ? (
               <div className="mt-3 flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
@@ -493,32 +460,6 @@ export default function Home({
               </div>
             ) : null}
           </div>
-
-          <aside className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
-            <div className="flex items-center gap-3">
-              <div className="grid h-10 w-10 place-items-center rounded-lg bg-sky-50 text-sky-700">
-                <Clock3 className="h-5 w-5" />
-              </div>
-              <div>
-                <p className="text-sm font-semibold text-zinc-950">实时抓取</p>
-                <p className="text-xs text-zinc-500">Apple RSS + iTunes Search</p>
-              </div>
-            </div>
-            <div className="mt-4 grid grid-cols-3 gap-2 text-center">
-              <div className="rounded-md bg-zinc-50 px-2 py-3">
-                <p className="text-lg font-semibold text-zinc-950">静态</p>
-                <p className="text-xs text-zinc-500">页面缓存</p>
-              </div>
-              <div className="rounded-md bg-zinc-50 px-2 py-3">
-                <p className="text-lg font-semibold text-zinc-950">400</p>
-                <p className="text-xs text-zinc-500">条评论</p>
-              </div>
-              <div className="rounded-md bg-zinc-50 px-2 py-3">
-                <p className="text-lg font-semibold text-zinc-950">摘要</p>
-                <p className="text-xs text-zinc-500">摘要结构</p>
-              </div>
-            </div>
-          </aside>
         </div>
       </section>
 
@@ -566,7 +507,7 @@ export default function Home({
                 ) : null}
               </div>
               <div className="mt-4 rounded-lg border border-teal-100 bg-teal-50 px-4 py-3 text-sm text-teal-800">
-                已{result.cached ? '读取缓存' : '生成缓存'}为 SEO 洞察页：<a href={result.pageUrl} className="font-semibold underline underline-offset-4">{result.pageUrl}</a>
+                已{result.cached ? '找到已有' : '生成'}评价洞察页：<a href={result.pageUrl} className="font-semibold underline underline-offset-4">{result.pageUrl}</a>
                 <span className="ml-2 text-teal-700">更新于 {formatFullDate(result.updatedAt)}</span>
               </div>
             </section>

--- a/src/components/app-review/site-footer.tsx
+++ b/src/components/app-review/site-footer.tsx
@@ -99,7 +99,7 @@ export function SiteFooter() {
             </div>
           </div>
           <p className="mt-4 max-w-xl text-sm leading-7 text-zinc-600">
-            向阳乔木把 AI 前沿变化转译成产品判断、可执行工作流、AI coding 实践和 GEO/AI 营销方法论。
+            向阳乔木把 AI 前沿变化转译成产品判断、可执行工作流、AI coding 实践和内容传播方法论。
           </p>
         </div>
 

--- a/src/components/app-review/top-charts-section.tsx
+++ b/src/components/app-review/top-charts-section.tsx
@@ -183,7 +183,7 @@ export function TopChartsSection({ countries, categories, initialApps }: TopChar
             </div>
             <h2 className="mt-2 text-xl font-semibold text-zinc-950">{title}</h2>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-zinc-500">
-              从 Apple 榜单选出基础 App 池，已生成的直接查看 DeepSeek 洞察，未生成的可一键生成缓存页。
+              从 Apple 榜单选出基础 App 池，已生成的直接查看洞察，未生成的可一键生成洞察页。
             </p>
           </div>
           <Button


### PR DESCRIPTION
## Summary
- remove the homepage quick chips under the search form and the right-side capability card from the hero
- remove public SEO/GEO/search-citation wording from homepage, detail page, metadata, footer, and Top Charts copy
- keep the underlying caching, metadata, and page generation behavior intact while making the visible copy product/user oriented

## Verification
- npx eslint src/components/app-review/home-client.tsx src/components/app-review/top-charts-section.tsx src/components/app-review/site-footer.tsx src/app/page.tsx src/app/layout.tsx 'src/app/apps/[country]/[appId]/[[...slug]]/page.tsx'
- npm run build
- local homepage HTML does not contain the removed hero/right-card copy or internal SEO/GEO/search-citation wording
- live /api/health returns deepseek-v4-flash
- live homepage HTML does not contain the removed hero/right-card copy or internal SEO/GEO/search-citation wording
- live ChatGPT detail page HTML does not contain SEO/GEO/AI search/search citation/TDK/structured-data wording