### PR TITLE
Limit public app insight generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 乔木App评价洞察
 
 > App Store 评论里藏着真实需求、付费阻力和竞品机会，但它们通常散在几百条吐槽里。
-> 乔木App评价洞察把这些评论变成产品经理、独立开发者和 GEO 内容团队能直接使用的洞察页面。
+> 乔木App评价洞察把这些评论变成产品经理、独立开发者和内容团队能直接使用的洞察页面。
 
 [![Live Demo](https://img.shields.io/badge/Live%20Demo-appreview.qiaomu.ai-0f766e?style=for-the-badge)](https://appreview.qiaomu.ai)
 [![Install Skill](https://img.shields.io/badge/Agent%20Skill-npx%20skills%20add-111827?style=for-the-badge)](#agent-skill)
@@ -19,9 +19,9 @@
 - 抓取 App Store 最新评论和评分分布
 - 用 DeepSeek v4 flash 提炼摘要、核心痛点、产品机会、正向信号、用户分层、版本风险和行动建议
 - 保留评论证据，避免只有空泛结论
-- 生成 SEO/GEO 友好的 App 静态洞察页
+- 生成可分享、可复盘的 App 洞察页
 - 基于版本和评论信息生成可视化图表，帮助定位需求和版本风险
-- 缓存每个 App 页面，记录更新时间，后续可重新生成
+- 缓存每个 App 页面，记录更新时间，后续可更新洞察
 - 预生成 Top Free / Top Paid 常用 App 页面，首页直接访问
 
 线上示例：
@@ -35,7 +35,7 @@
 | --- | --- |
 | 产品经理 | 从真实差评里找需求、风险和优先级 |
 | 独立开发者 | 快速研究竞品差评，找到小产品切入口 |
-| 增长 / SEO / GEO 团队 | 把 App 评价变成可被搜索引擎和生成式搜索引用的内容资产 |
+| 增长 / 内容团队 | 把 App 评价变成有证据、有结构的内容素材 |
 | 投研 / 行研 | 批量观察热门 App 的用户口碑变化 |
 | Agent 用户 | 安装 skill 后，用自然语言触发 App 评价洞察工作流 |
 
@@ -45,7 +45,7 @@
 
 | 模块 | 输出价值 |
 | --- | --- |
-| 摘要 | 一段可被 SEO/GEO 引用的产品口碑概述 |
+| 摘要 | 一段清晰的产品口碑概述 |
 | 核心痛点 | 用户反复抱怨的问题，附证据句 |
 | 产品机会 | 可以转成需求池或路线图的机会 |
 | 正向信号 | 用户愿意给高分的关键价值点 |
@@ -79,6 +79,20 @@ STORAGE_TYPE=local
 ```
 
 > 不要把 `.env.local`、`.env.development` 或任何真实 API Key 提交到仓库。
+
+公开部署时建议打开生成保护：
+
+```env
+APP_REVIEW_PUBLIC_DAILY_NEW_APP_LIMIT=5
+APP_REVIEW_PUBLIC_CACHE_FRESH_DAYS=3
+APP_REVIEW_GENERATION_LIMIT_DIR=/app/src/data/app-cache/.generation-guard
+APP_REVIEW_HISTORY_DIR=/app/src/data/app-cache/.review-history
+```
+
+- `APP_REVIEW_PUBLIC_DAILY_NEW_APP_LIMIT`: 同一 IP 每天最多生成多少个新 App 页面，默认 5。
+- `APP_REVIEW_PUBLIC_CACHE_FRESH_DAYS`: 已有页面在多少天内直接读取，不触发新生成，默认 3。
+- `APP_REVIEW_GENERATION_LIMIT_DIR`: 限流记录和待生成队列的存储目录。
+- `APP_REVIEW_HISTORY_DIR`: 历史评论仓库目录，会按 App 累积保存已经抓到过的评论样本。
 
 ## 预生成热门 App 页面
 
@@ -128,7 +142,7 @@ curl -X POST http://localhost:3000/api/research \
   -d '{"query":"ChatGPT","country":"us","maxReviews":160}'
 ```
 
-强制重新生成：
+更新洞察：
 
 ```bash
 curl -X POST http://localhost:3000/api/research/regenerate \
@@ -154,7 +168,7 @@ npx skills add joeseesun/qiaomu-app-review-skill
 
 - `分析 ChatGPT 的 App Store 用户评价，重点看版本风险和产品机会`
 - `帮我找一个同类 App 的差评痛点，看看有没有独立开发机会`
-- `把这个 App 的评论整理成 SEO/GEO 友好的洞察页结构`
+- `把这个 App 的评论整理成产品洞察页结构`
 
 Skill 会引导 Agent 使用本项目的公开站点、API、缓存和 DeepSeek flash 分析流程。
 
@@ -182,9 +196,9 @@ Skill 会引导 Agent 使用本项目的公开站点、API、缓存和 DeepSeek 
 | --- | --- |
 | `AI 服务密钥未配置或不可用` | 检查 `.env.local` 里的 `QIAOMU_LLM_API_KEY` 或 `DEEPSEEK_API_KEY` 是否存在，重启 dev server。 |
 | 搜索到的 App 不对 | 带上国家区和 App Store 链接，例如 `https://apps.apple.com/us/app/chatgpt/id6448311069`。 |
-| 详情页没有 AI 摘要 | 点击重新生成，或确认当前服务能访问 LLM API。也可以先用 `--no-analyze` 只生成评论缓存。 |
+| 详情页没有 AI 摘要 | 点击更新洞察，或确认当前服务能访问 LLM API。也可以先用 `--no-analyze` 只生成评论缓存。 |
 | Docker 启动后无缓存 | 确认 `APP_REVIEW_CACHE_DIR` 指向容器内可写路径，并挂载 volume。 |
-| 线上域名生成的 canonical 不对 | 设置 `NEXT_PUBLIC_SITE_URL=https://你的域名` 后重新生成缓存页。 |
+| 线上域名生成的页面链接不对 | 设置 `NEXT_PUBLIC_SITE_URL=https://你的域名` 后更新缓存页。 |
 
 ## 关于向阳乔木
 

--- a/src/app/api/research/regenerate/route.ts
+++ b/src/app/api/research/regenerate/route.ts
@@ -44,7 +44,8 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
       return NextResponse.json({ success: false, error: '缺少有效 App ID' }, { status: 400 });
     }
 
-    const incremental = body.incremental === true;
+    const allowPublicFullRegenerate = process.env.APP_REVIEW_ALLOW_PUBLIC_FORCE === 'true';
+    const incremental = allowPublicFullRegenerate ? body.incremental !== false : true;
     const { page, cached } = await generateCachedReviewPage({
       appId,
       country: normalizeCountry(body.country),

--- a/src/app/api/research/route.ts
+++ b/src/app/api/research/route.ts
@@ -1,7 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ReviewMiningResponse } from '@/lib/analysis/kimi-client';
-import { ReviewSourceBreakdown, generateCachedReviewPage } from '@/lib/appstore/cache';
+import {
+  CachedAppReviewPage,
+  ReviewSourceBreakdown,
+  generateCachedReviewPage,
+  readCachedReviewPage,
+  resolveAppForCache,
+} from '@/lib/appstore/cache';
 import { ReviewDiagnostics } from '@/lib/appstore/diagnostics';
+import {
+  GenerationLimitInfo,
+  appGenerationKey,
+  hasInFlightGeneration,
+  isFreshCachedPage,
+  publicCacheFreshDays,
+  queuePublicGeneration,
+  reservePublicGeneration,
+  runDedupedGeneration,
+} from '@/lib/appstore/generation-guard';
 import { normalizeCountry, AppStoreLookupResult } from '@/lib/appstore/discovery';
 import { ReviewStats } from '@/lib/appstore/review-summary';
 import { ApiResponse, AppStoreReview } from '@/types';
@@ -30,6 +46,11 @@ interface ResearchResponse {
   pageUrl: string;
   updatedAt: string;
   cached: boolean;
+  generation?: {
+    status: 'cached' | 'generated' | 'deduped' | 'queued';
+    message?: string;
+    limit?: GenerationLimitInfo;
+  };
   model?: {
     provider: string;
     model: string;
@@ -50,6 +71,39 @@ function safeErrorMessage(error: unknown): string {
   return error.message;
 }
 
+function shouldGeneratePage(page: CachedAppReviewPage | null, options: {
+  force: boolean;
+  freshDays: number;
+}) {
+  if (!page) return true;
+  if (options.force) return true;
+  if (isFreshCachedPage(page, options.freshDays)) return false;
+  return true;
+}
+
+function researchResponse(
+  page: CachedAppReviewPage,
+  cached: boolean,
+  generation?: ResearchResponse['generation']
+): ResearchResponse {
+  return {
+    app: page.app,
+    candidates: page.candidates,
+    source: page.source,
+    stats: page.stats,
+    reviews: page.reviews,
+    sourceBreakdown: page.sourceBreakdown,
+    diagnostics: page.diagnostics,
+    insights: page.insights,
+    aiError: page.aiError,
+    pageUrl: page.pagePath,
+    updatedAt: page.updatedAt,
+    cached,
+    generation,
+    model: page.model,
+  };
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse<ApiResponse<ResearchResponse>>> {
   try {
     const body = await request.json() as ResearchRequest;
@@ -57,33 +111,77 @@ export async function POST(request: NextRequest): Promise<NextResponse<ApiRespon
     const country = normalizeCountry(body.country);
     const maxReviews = clampReviewLimit(body.maxReviews);
     const shouldAnalyze = body.analyze !== false;
-    const force = body.force === true;
+    const publicForceEnabled = process.env.APP_REVIEW_ALLOW_PUBLIC_FORCE === 'true';
+    const force = publicForceEnabled && body.force === true;
+    const freshDays = publicCacheFreshDays();
+    const resolution = await resolveAppForCache({ query, country });
+    const resolvedCountry = normalizeCountry(resolution.app.country);
+    const existing = await readCachedReviewPage(resolvedCountry, resolution.app.id);
 
-    const { page, cached } = await generateCachedReviewPage({
+    if (!shouldGeneratePage(existing, { force, freshDays })) {
+      return NextResponse.json({
+        success: true,
+        data: researchResponse(existing!, true, {
+          status: 'cached',
+        }),
+      });
+    }
+
+    const appKey = appGenerationKey(resolvedCountry, resolution.app.id);
+    const alreadyInFlight = hasInFlightGeneration(appKey);
+
+    if (!alreadyInFlight) {
+      const reservation = await reservePublicGeneration(request, appKey);
+
+      if (!reservation.allowed) {
+        const limit = await queuePublicGeneration(request, {
+          appKey,
+          appId: resolution.app.id,
+          appName: resolution.app.name,
+          country: resolvedCountry,
+          query,
+          reason: 'rate-limited',
+        });
+        const message = existing
+          ? '今天的新 App 生成次数已用完，已记录这个 App。你可以先查看已有洞察页，稍后再回来更新。'
+          : '今天的新 App 生成次数已用完，已记录这个 App，稍后会进入后台生成队列。';
+
+        if (existing) {
+          return NextResponse.json({
+            success: true,
+            data: researchResponse(existing, true, {
+              status: 'queued',
+              message,
+              limit,
+            }),
+          });
+        }
+
+        return NextResponse.json(
+          {
+            success: false,
+            error: message,
+          },
+          { status: 429 }
+        );
+      }
+    }
+
+    const { result, deduped } = await runDedupedGeneration(appKey, () => generateCachedReviewPage({
       query,
-      country,
+      country: resolvedCountry,
       maxReviews,
       analyze: shouldAnalyze,
-      force,
-    });
+      force: force || Boolean(existing && !isFreshCachedPage(existing, freshDays)),
+      resolution,
+    }));
+    const { page, cached } = result;
 
     return NextResponse.json({
       success: true,
-      data: {
-        app: page.app,
-        candidates: page.candidates,
-        source: page.source,
-        stats: page.stats,
-        reviews: page.reviews,
-        sourceBreakdown: page.sourceBreakdown,
-        diagnostics: page.diagnostics,
-        insights: page.insights,
-        aiError: page.aiError,
-        pageUrl: page.pagePath,
-        updatedAt: page.updatedAt,
-        cached,
-        model: page.model,
-      },
+      data: researchResponse(page, cached, {
+        status: cached ? 'cached' : deduped ? 'deduped' : 'generated',
+      }),
     });
   } catch (error) {
     console.error('Research request failed:', error);

--- a/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
+++ b/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { AlertCircle, Apple, ArrowLeft, ArrowUpRight, Lightbulb, Star, Target, TrendingDown } from 'lucide-react';
 import { InsightGrid } from '@/components/app-review/insight-cards';
 import { RegenerateButton } from '@/components/app-review/regenerate-button';
-import { SiteFooter } from '@/components/app-review/site-footer';
+import { BrandMark, SiteFooter } from '@/components/app-review/site-footer';
 import { ReviewSourceBreakdownPanel, reviewSourceLabel } from '@/components/app-review/source-breakdown';
 import { VersionDiagnosticsPanel } from '@/components/app-review/version-diagnostics';
 import {
@@ -164,11 +164,7 @@ export default async function AppInsightPage({ params }: PageProps) {
       <header className="border-b border-zinc-200 bg-white/90">
         <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
           <Link href="/" className="flex items-center gap-3">
-            <img src="/logo.svg" alt="乔木App评价洞察 Logo" className="h-9 w-9 rounded-lg shadow-sm" />
-            <div>
-              <p className="text-sm font-semibold text-zinc-950">乔木App评价洞察</p>
-              <p className="text-xs text-zinc-500">App Review Insights</p>
-            </div>
+            <BrandMark compact />
           </Link>
           <Link href="/" className="inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-950">
             <ArrowLeft className="h-4 w-4" />
@@ -284,7 +280,7 @@ export default async function AppInsightPage({ params }: PageProps) {
           ) : (
             <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
               <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{page.aiError || 'AI 洞察暂未生成或需要重新生成；页面仍保留评分、版本和评论证据。'}</span>
+              <span>{page.aiError || 'AI 洞察暂未生成或需要更新；页面仍保留评分、版本和评论证据。'}</span>
             </div>
           )}
         </div>
@@ -357,7 +353,7 @@ export default async function AppInsightPage({ params }: PageProps) {
           <div>
             <Target className="h-5 w-5 text-teal-600" />
             <h2 className="mt-3 text-base font-semibold text-zinc-950">数据如何更新？</h2>
-            <p className="mt-2 text-sm leading-6 text-zinc-500">页面记录更新时间，可点击重新生成，抓取最新评论并更新当前洞察页。</p>
+            <p className="mt-2 text-sm leading-6 text-zinc-500">页面记录更新时间，可点击更新洞察，抓取最新评论并更新当前页面。</p>
           </div>
         </div>
       </section>

--- a/src/components/app-review/home-client.tsx
+++ b/src/components/app-review/home-client.tsx
@@ -12,9 +12,10 @@ import {
   Search,
   Star,
   TrendingDown,
+  X,
 } from 'lucide-react';
 import { InsightGrid } from '@/components/app-review/insight-cards';
-import { SiteAffordances, SiteFooter } from '@/components/app-review/site-footer';
+import { BrandMark, RewardSupportDialog, SiteAffordances, SiteFooter } from '@/components/app-review/site-footer';
 import {
   ReviewSourceBreakdown,
   ReviewSourceBreakdownPanel,
@@ -84,6 +85,16 @@ interface ResearchData {
   pageUrl: string;
   updatedAt: string;
   cached: boolean;
+  generation?: {
+    status: 'cached' | 'generated' | 'deduped' | 'queued';
+    message?: string;
+    limit?: {
+      limit: number;
+      used: number;
+      remaining: number;
+      resetAt: string;
+    };
+  };
   model?: {
     provider: string;
     model: string;
@@ -353,6 +364,7 @@ export default function Home({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState<ResearchData | null>(null);
+  const [rewardOpen, setRewardOpen] = useState(false);
 
   const maxBucket = useMemo(() => result ? maxRatingBucket(result.stats) : 1, [result]);
   const visibleInsights = result?.insights && hasMeaningfulClientInsights(result.insights) ? result.insights : null;
@@ -373,10 +385,16 @@ export default function Home({
       const payload = await response.json() as ApiResponse<ResearchData>;
 
       if (!response.ok || !payload.success || !payload.data) {
+        if (response.status === 429) {
+          setRewardOpen(true);
+        }
         throw new Error(payload.error || '检索失败');
       }
 
       setResult(payload.data);
+      if (payload.data.generation?.status === 'queued') {
+        setRewardOpen(true);
+      }
     } catch (researchError) {
       setError(researchError instanceof Error ? researchError.message : '检索失败');
     } finally {
@@ -388,13 +406,7 @@ export default function Home({
     <main className="min-h-screen bg-[#f7f7f4] text-zinc-950">
       <header className="border-b border-zinc-200 bg-white/90">
         <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-3">
-            <img src="/logo.svg" alt="乔木App评价洞察 Logo" className="h-9 w-9 rounded-lg shadow-sm" />
-            <div>
-              <p className="text-sm font-semibold text-zinc-950">乔木App评价洞察</p>
-              <p className="text-xs text-zinc-500">appreview.qiaomu.ai</p>
-            </div>
-          </div>
+          <BrandMark compact />
           <div className="flex items-center gap-2">
             <SiteAffordances subtle />
           </div>
@@ -404,10 +416,7 @@ export default function Home({
       <section className="border-b border-zinc-200 bg-[#fdfdfb]">
         <div className="mx-auto max-w-7xl px-4 py-7 sm:px-6 lg:px-8">
           <div className="min-w-0">
-            <h1 className="max-w-4xl text-3xl font-semibold leading-tight text-zinc-950 sm:text-4xl">
-              乔木App评价洞察
-            </h1>
-            <p className="mt-3 max-w-3xl text-base leading-7 text-zinc-600">
+            <p className="max-w-3xl text-base leading-7 text-zinc-600">
               搜索 App Store 应用，生成用户评价洞察页，提炼痛点、机会、版本风险和关键摘要。
             </p>
             <form onSubmit={runResearch} className="mt-6 rounded-lg border border-zinc-200 bg-white p-3 shadow-sm">
@@ -418,8 +427,21 @@ export default function Home({
                     value={query}
                     onChange={(event) => setQuery(event.target.value)}
                     placeholder="App Store 链接、App ID 或应用名称"
-                    className="h-11 rounded-md border-zinc-200 bg-zinc-50 pl-9 text-base focus-visible:ring-zinc-900"
+                    className="h-11 rounded-md border-zinc-200 bg-zinc-50 pl-9 pr-10 text-base focus-visible:ring-zinc-900"
                   />
+                  {query ? (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setQuery('');
+                        setError('');
+                      }}
+                      aria-label="清除搜索内容"
+                      className="absolute right-3 top-1/2 grid h-6 w-6 -translate-y-1/2 place-items-center rounded-md text-zinc-400 transition hover:bg-zinc-100 hover:text-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-900/15"
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  ) : null}
                 </div>
                 <div className="relative">
                   <select
@@ -510,6 +532,11 @@ export default function Home({
                 已{result.cached ? '找到已有' : '生成'}评价洞察页：<a href={result.pageUrl} className="font-semibold underline underline-offset-4">{result.pageUrl}</a>
                 <span className="ml-2 text-teal-700">更新于 {formatFullDate(result.updatedAt)}</span>
               </div>
+              {result.generation?.message ? (
+                <div className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-800">
+                  {result.generation.message}
+                </div>
+              ) : null}
             </section>
 
             <section className="min-w-0 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
@@ -603,7 +630,7 @@ export default function Home({
               </>
             ) : (
               <div className="rounded-lg bg-zinc-50 px-4 py-8 text-center text-sm text-zinc-500">
-                {result.stats.totalReviews > 0 ? 'AI 洞察暂未生成或需要重新生成。' : '暂无评论样本。'}
+                {result.stats.totalReviews > 0 ? 'AI 洞察暂未生成或需要更新。' : '暂无评论样本。'}
               </div>
             )}
           </section>
@@ -676,6 +703,7 @@ export default function Home({
         </>
       )}
       <SiteFooter />
+      <RewardSupportDialog open={rewardOpen} onOpenChange={setRewardOpen} />
     </main>
   );
 }

--- a/src/components/app-review/regenerate-button.tsx
+++ b/src/components/app-review/regenerate-button.tsx
@@ -20,30 +20,30 @@ interface RegenerateResponse {
 }
 
 export function RegenerateButton({ appId, country }: RegenerateButtonProps) {
-  const [loadingMode, setLoadingMode] = useState<'incremental' | 'full' | null>(null);
+  const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const regenerate = async (incremental: boolean) => {
-    setLoadingMode(incremental ? 'incremental' : 'full');
+  const regenerate = async () => {
+    setLoading(true);
     setError('');
 
     try {
       const response = await fetch('/api/research/regenerate', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ appId, country, maxReviews: 400, analyze: true, incremental }),
+        body: JSON.stringify({ appId, country, maxReviews: 400, analyze: true, incremental: true }),
       });
       const payload = await response.json() as RegenerateResponse;
 
       if (!response.ok || !payload.success || !payload.data) {
-        throw new Error(payload.error || '重新生成失败');
+        throw new Error(payload.error || '更新失败');
       }
 
       window.location.href = `${payload.data.pageUrl}?updated=${Date.now()}`;
     } catch (regenerateError) {
-      setError(regenerateError instanceof Error ? regenerateError.message : '重新生成失败');
+      setError(regenerateError instanceof Error ? regenerateError.message : '更新失败');
     } finally {
-      setLoadingMode(null);
+      setLoading(false);
     }
   };
 
@@ -52,21 +52,12 @@ export function RegenerateButton({ appId, country }: RegenerateButtonProps) {
       <div className="flex flex-wrap gap-2">
         <button
           type="button"
-          onClick={() => regenerate(true)}
-          disabled={Boolean(loadingMode)}
-          className="inline-flex items-center gap-2 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm font-medium text-zinc-700 transition hover:border-zinc-300 hover:text-zinc-950 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <RefreshCw className={`h-4 w-4 ${loadingMode === 'incremental' ? 'animate-spin' : ''}`} />
-          增量更新
-        </button>
-        <button
-          type="button"
-          onClick={() => regenerate(false)}
-          disabled={Boolean(loadingMode)}
+          onClick={regenerate}
+          disabled={loading}
           className="inline-flex items-center gap-2 rounded-md bg-zinc-950 px-3 py-2 text-sm font-medium text-white transition hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-60"
         >
-          <RefreshCw className={`h-4 w-4 ${loadingMode === 'full' ? 'animate-spin' : ''}`} />
-          重新生成
+          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          更新洞察
         </button>
       </div>
       {error ? <p className="text-xs text-rose-600">{error}</p> : null}

--- a/src/components/app-review/site-footer.tsx
+++ b/src/components/app-review/site-footer.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { ArrowUpRight, Gift, Github, MessageCircle, QrCode, Sparkles } from 'lucide-react';
 import {
   Dialog,
@@ -18,6 +19,55 @@ const profileLinks = [
   { label: 'X', href: 'https://x.com/vista8' },
 ];
 
+function BrandName({ className = 'text-lg' }: { className?: string }) {
+  return (
+    <p
+      className={`${className} font-semibold leading-none text-zinc-950`}
+      style={{ fontFamily: '"Noto Serif SC", "Source Han Serif SC", "Songti SC", "STSong", SimSun, serif' }}
+    >
+      乔木App洞察
+    </p>
+  );
+}
+
+export function BrandMark({ compact = false }: { compact?: boolean }) {
+  return (
+    <div className="flex items-center gap-3">
+      <img src="/logo.svg" alt="乔木App洞察 Logo" className={`${compact ? 'h-9 w-9' : 'h-10 w-10'} rounded-lg shadow-sm`} />
+      <BrandName className={compact ? 'text-lg' : 'text-xl'} />
+    </div>
+  );
+}
+
+export function RewardSupportDialog({
+  open,
+  onOpenChange,
+  trigger,
+}: {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: ReactNode;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {trigger ? <DialogTrigger asChild>{trigger}</DialogTrigger> : null}
+      <DialogContent className="max-w-sm rounded-lg border-zinc-200 bg-white">
+        <DialogHeader>
+          <DialogTitle>支持向阳乔木继续开发</DialogTitle>
+          <DialogDescription>
+            如果这个工具帮你节省了时间，可以打赏支持更多免费 AI 工具和评论洞察额度。
+          </DialogDescription>
+        </DialogHeader>
+        <img
+          src="/qiaomu/reward.png"
+          alt="打赏二维码"
+          className="mx-auto max-h-[62vh] w-full max-w-[260px] rounded-lg border border-zinc-200 object-contain"
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function SiteAffordances({ subtle = false }: { subtle?: boolean }) {
   const buttonClass = subtle
     ? 'grid h-9 w-9 place-items-center rounded-md border border-zinc-200 bg-white text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-950 focus:outline-none focus:ring-2 focus:ring-zinc-900/15'
@@ -25,24 +75,13 @@ export function SiteAffordances({ subtle = false }: { subtle?: boolean }) {
 
   return (
     <div className="flex items-center gap-2">
-      <Dialog>
-        <DialogTrigger asChild>
+      <RewardSupportDialog
+        trigger={
           <button type="button" title="打赏支持" aria-label="打赏支持" className={buttonClass}>
             <Gift className="h-4 w-4" />
           </button>
-        </DialogTrigger>
-        <DialogContent className="max-w-sm rounded-lg border-zinc-200 bg-white">
-          <DialogHeader>
-            <DialogTitle>打赏支持</DialogTitle>
-            <DialogDescription>谢谢支持向阳乔木继续打磨实用 AI 工具。</DialogDescription>
-          </DialogHeader>
-          <img
-            src="/qiaomu/reward.png"
-            alt="打赏二维码"
-            className="mx-auto max-h-[62vh] w-full max-w-[260px] rounded-lg border border-zinc-200 object-contain"
-          />
-        </DialogContent>
-      </Dialog>
+        }
+      />
 
       <Dialog>
         <DialogTrigger asChild>
@@ -91,13 +130,7 @@ export function SiteFooter() {
     <footer className="border-t border-zinc-200 bg-[#fdfdfb]">
       <div className="mx-auto grid max-w-7xl gap-8 px-4 py-8 sm:px-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_auto] lg:px-8">
         <div className="min-w-0">
-          <div className="flex items-center gap-3">
-            <img src="/logo.svg" alt="乔木App评价洞察 Logo" className="h-10 w-10 rounded-lg shadow-sm" />
-            <div>
-              <p className="text-sm font-semibold text-zinc-950">乔木App评价洞察</p>
-              <p className="text-xs text-zinc-500">向阳乔木的 App Store 评论洞察工具</p>
-            </div>
-          </div>
+          <BrandMark />
           <p className="mt-4 max-w-xl text-sm leading-7 text-zinc-600">
             向阳乔木把 AI 前沿变化转译成产品判断、可执行工作流、AI coding 实践和内容传播方法论。
           </p>

--- a/src/components/app-review/top-charts-section.tsx
+++ b/src/components/app-review/top-charts-section.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { ArrowUpRight, Bot, ChevronsUpDown, Loader2, RefreshCw, Trophy } from 'lucide-react';
+import { RewardSupportDialog } from '@/components/app-review/site-footer';
 import { Button } from '@/components/ui/button';
 
 type TopChartType = 'free' | 'paid';
@@ -69,8 +70,8 @@ export function TopChartsSection({ countries, categories, initialApps }: TopChar
   const [apps, setApps] = useState<TopChartApp[]>(initialApps);
   const [loading, setLoading] = useState(false);
   const [generatingId, setGeneratingId] = useState('');
-  const [batchGenerating, setBatchGenerating] = useState(false);
   const [error, setError] = useState('');
+  const [rewardOpen, setRewardOpen] = useState(false);
 
   const title = useMemo(
     () => `${optionLabel(countries, country)} · ${optionLabel(categories, category)} · ${chartLabel(chart)} Top 10`,
@@ -138,10 +139,20 @@ export function TopChartsSection({ countries, categories, initialApps }: TopChar
           negativeShare: number;
         };
         insights: unknown;
+        generation?: {
+          status: 'cached' | 'generated' | 'deduped' | 'queued';
+          message?: string;
+        };
       }>;
 
       if (!response.ok || !payload.success || !payload.data) {
+        if (response.status === 429) {
+          setRewardOpen(true);
+        }
         throw new Error(payload.error || '生成洞察失败');
+      }
+      if (payload.data.generation?.status === 'queued') {
+        setRewardOpen(true);
       }
 
       setApps((items) => items.map((item) => item.id === app.id ? {
@@ -162,16 +173,6 @@ export function TopChartsSection({ countries, categories, initialApps }: TopChar
     }
   };
 
-  const generateTop10 = async () => {
-    setBatchGenerating(true);
-    for (const app of apps) {
-      if (!app.cached) {
-        await generateInsight(app);
-      }
-    }
-    setBatchGenerating(false);
-  };
-
   return (
     <section className="mx-auto max-w-7xl px-4 pt-6 sm:px-6 lg:px-8">
       <div className="rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
@@ -183,18 +184,9 @@ export function TopChartsSection({ countries, categories, initialApps }: TopChar
             </div>
             <h2 className="mt-2 text-xl font-semibold text-zinc-950">{title}</h2>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-zinc-500">
-              从 Apple 榜单选出基础 App 池，已生成的直接查看洞察，未生成的可一键生成洞察页。
+              从 Apple 榜单选出基础 App 池，已生成的直接查看洞察，未生成的可以单独生成洞察页。
             </p>
           </div>
-          <Button
-            type="button"
-            onClick={generateTop10}
-            disabled={batchGenerating || loading || apps.length === 0}
-            className="rounded-md bg-zinc-950 text-white hover:bg-zinc-800"
-          >
-            {batchGenerating ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Bot className="mr-2 h-4 w-4" />}
-            生成本榜 Top10
-          </Button>
         </div>
 
         <div className="mt-4 grid gap-3 md:grid-cols-[150px_minmax(0,1fr)_130px_44px]">
@@ -278,7 +270,7 @@ export function TopChartsSection({ countries, categories, initialApps }: TopChar
                   <button
                     type="button"
                     onClick={() => generateInsight(app)}
-                    disabled={Boolean(generatingId) || batchGenerating}
+                    disabled={Boolean(generatingId)}
                     className="inline-flex items-center gap-1 rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm text-zinc-700 transition hover:border-zinc-300 hover:text-zinc-950 disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     {generatingId === app.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Bot className="h-3.5 w-3.5" />}
@@ -296,6 +288,7 @@ export function TopChartsSection({ countries, categories, initialApps }: TopChar
           ))}
         </div>
       </div>
+      <RewardSupportDialog open={rewardOpen} onOpenChange={setRewardOpen} />
     </section>
   );
 }

--- a/src/lib/appstore/cache.ts
+++ b/src/lib/appstore/cache.ts
@@ -12,6 +12,7 @@ import {
   resolveAppQuery,
 } from '@/lib/appstore/discovery';
 import { ReviewDiagnostics, buildReviewDiagnostics } from '@/lib/appstore/diagnostics';
+import { upsertReviewHistory } from '@/lib/appstore/review-history';
 import { ReviewStats, sortReviewsForAnalysis, summarizeReviews } from '@/lib/appstore/review-summary';
 import { AppReviewSource, AppStoreReview } from '@/types';
 
@@ -85,6 +86,7 @@ interface GenerateCachedReviewOptions {
   analyze?: boolean;
   force?: boolean;
   incremental?: boolean;
+  resolution?: AppResolution;
 }
 
 interface GenerateCachedReviewResult {
@@ -364,7 +366,7 @@ async function atomicWriteJson(filePath: string, data: unknown) {
   await fs.rename(tmpPath, filePath);
 }
 
-async function resolveApp(options: GenerateCachedReviewOptions): Promise<AppResolution> {
+export async function resolveAppForCache(options: GenerateCachedReviewOptions): Promise<AppResolution> {
   const country = normalizeCountry(options.country);
 
   if (options.appId) {
@@ -450,7 +452,7 @@ export async function getCachedAppSummaries(): Promise<FeaturedAppSummary[]> {
 }
 
 export async function generateCachedReviewPage(options: GenerateCachedReviewOptions): Promise<GenerateCachedReviewResult> {
-  const resolution = await resolveApp(options);
+  const resolution = options.resolution || await resolveAppForCache(options);
   const country = normalizeCountry(resolution.app.country);
   const maxReviews = clampReviewLimit(options.maxReviews);
   const existing = await readCachedReviewPage(country, resolution.app.id);
@@ -513,7 +515,7 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
       return { page: existing, cached: true };
     }
 
-    throw new Error(`App Store 暂时没有返回 ${resolution.app.name} 的评论正文，但该应用有 ${resolution.app.userRatingCount} 个评分。请稍后重新生成。`);
+    throw new Error(`App Store 暂时没有返回 ${resolution.app.name} 的评论正文，但该应用有 ${resolution.app.userRatingCount} 个评分。请稍后更新。`);
   }
 
   const allReviews = sortReviewsByDateDesc(reviews).slice(0, maxReviews);
@@ -571,6 +573,7 @@ export async function generateCachedReviewPage(options: GenerateCachedReviewOpti
     maxReviews,
   };
 
+  await upsertReviewHistory(page.app, allReviews);
   await atomicWriteJson(cacheFilePath(country, resolution.app.id), page);
   return { page, cached: false };
 }

--- a/src/lib/appstore/diagnostics.ts
+++ b/src/lib/appstore/diagnostics.ts
@@ -236,7 +236,7 @@ function buildInsights(
     } : {
       label: '主导痛点',
       value: '暂无集中主题',
-      description: '当前差评主题分散，建议继续扩大样本或重新生成。',
+      description: '当前差评主题分散，建议继续扩大样本或更新洞察。',
       tone: 'zinc',
     },
     spikeDay && spikeDay.negative > 0 ? {

--- a/src/lib/appstore/generation-guard.ts
+++ b/src/lib/appstore/generation-guard.ts
@@ -1,0 +1,240 @@
+import 'server-only';
+
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { NextRequest } from 'next/server';
+import { CachedAppReviewPage } from '@/lib/appstore/cache';
+
+const DEFAULT_DAILY_LIMIT = 5;
+const DEFAULT_FRESH_DAYS = 3;
+
+interface DailyClientState {
+  generatedAppKeys: string[];
+  queuedAppKeys: string[];
+  updatedAt: string;
+}
+
+interface DailyGenerationState {
+  day: string;
+  clients: Record<string, DailyClientState>;
+}
+
+export interface GenerationLimitInfo {
+  limit: number;
+  used: number;
+  remaining: number;
+  resetAt: string;
+}
+
+export interface GenerationReservation {
+  allowed: boolean;
+  clientKey: string;
+  limit: GenerationLimitInfo;
+}
+
+export interface QueuedGenerationRequest {
+  appKey: string;
+  appId: string;
+  appName?: string;
+  country: string;
+  query?: string;
+  reason: 'rate-limited';
+}
+
+const inFlightGenerations = new Map<string, Promise<unknown>>();
+
+function dataRoot() {
+  return process.env.APP_REVIEW_GENERATION_LIMIT_DIR
+    || path.join(
+      process.env.APP_REVIEW_CACHE_DIR || path.join(process.cwd(), 'src', 'data', 'app-cache'),
+      '.generation-guard'
+    );
+}
+
+function dailyLimit() {
+  const parsed = Number.parseInt(process.env.APP_REVIEW_PUBLIC_DAILY_NEW_APP_LIMIT || '', 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_DAILY_LIMIT;
+  return Math.max(0, parsed);
+}
+
+export function publicCacheFreshDays() {
+  const parsed = Number.parseInt(process.env.APP_REVIEW_PUBLIC_CACHE_FRESH_DAYS || '', 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_FRESH_DAYS;
+  return Math.max(1, parsed);
+}
+
+function dayKey(date = new Date()) {
+  return date.toISOString().slice(0, 10);
+}
+
+function resetAtForDay(day: string) {
+  const date = new Date(`${day}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + 1);
+  return date.toISOString();
+}
+
+function stateFilePath(day = dayKey()) {
+  return path.join(dataRoot(), 'daily', `${day}.json`);
+}
+
+function queueFilePath(day = dayKey()) {
+  return path.join(dataRoot(), 'queue', `${day}.jsonl`);
+}
+
+function clientIp(request: NextRequest) {
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  return request.headers.get('cf-connecting-ip')
+    || request.headers.get('x-real-ip')
+    || forwardedFor
+    || (request as unknown as { ip?: string }).ip
+    || 'unknown';
+}
+
+export function clientGenerationKey(request: NextRequest) {
+  return crypto
+    .createHash('sha256')
+    .update(`appreview-public-generation:${clientIp(request)}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+export function appGenerationKey(country: string, appId: string) {
+  return `${country.toLowerCase()}-${appId.replace(/\D/g, '')}`;
+}
+
+export function isFreshCachedPage(page: CachedAppReviewPage | null, freshDays = publicCacheFreshDays()) {
+  if (!page?.updatedAt) return false;
+  const updatedAt = new Date(page.updatedAt).getTime();
+  if (!Number.isFinite(updatedAt)) return false;
+  return Date.now() - updatedAt < freshDays * 24 * 60 * 60 * 1000;
+}
+
+async function ensureDir(filePath: string) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+}
+
+async function readDailyState(day = dayKey()): Promise<DailyGenerationState> {
+  try {
+    const content = await fs.readFile(stateFilePath(day), 'utf8');
+    const parsed = JSON.parse(content) as DailyGenerationState;
+    return {
+      day,
+      clients: parsed.clients || {},
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    return { day, clients: {} };
+  }
+}
+
+async function writeDailyState(state: DailyGenerationState) {
+  const filePath = stateFilePath(state.day);
+  await ensureDir(filePath);
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+function getClientState(state: DailyGenerationState, clientKey: string) {
+  state.clients[clientKey] ||= {
+    generatedAppKeys: [],
+    queuedAppKeys: [],
+    updatedAt: new Date().toISOString(),
+  };
+  state.clients[clientKey].generatedAppKeys ||= [];
+  state.clients[clientKey].queuedAppKeys ||= [];
+  return state.clients[clientKey];
+}
+
+function limitInfo(client: DailyClientState, limit: number, day: string): GenerationLimitInfo {
+  const used = new Set(client.generatedAppKeys).size;
+  return {
+    limit,
+    used,
+    remaining: Math.max(0, limit - used),
+    resetAt: resetAtForDay(day),
+  };
+}
+
+export async function reservePublicGeneration(request: NextRequest, appKey: string): Promise<GenerationReservation> {
+  const day = dayKey();
+  const clientKey = clientGenerationKey(request);
+  const state = await readDailyState(day);
+  const client = getClientState(state, clientKey);
+  const limit = dailyLimit();
+  const generated = new Set(client.generatedAppKeys);
+
+  if (!generated.has(appKey) && generated.size >= limit) {
+    return {
+      allowed: false,
+      clientKey,
+      limit: limitInfo(client, limit, day),
+    };
+  }
+
+  if (!generated.has(appKey)) {
+    client.generatedAppKeys.push(appKey);
+  }
+
+  client.updatedAt = new Date().toISOString();
+  await writeDailyState(state);
+
+  return {
+    allowed: true,
+    clientKey,
+    limit: limitInfo(client, limit, day),
+  };
+}
+
+export async function queuePublicGeneration(
+  request: NextRequest,
+  requestInfo: QueuedGenerationRequest
+): Promise<GenerationLimitInfo> {
+  const day = dayKey();
+  const clientKey = clientGenerationKey(request);
+  const state = await readDailyState(day);
+  const client = getClientState(state, clientKey);
+
+  if (!client.queuedAppKeys.includes(requestInfo.appKey)) {
+    client.queuedAppKeys.push(requestInfo.appKey);
+  }
+
+  client.updatedAt = new Date().toISOString();
+  await writeDailyState(state);
+
+  const queuePath = queueFilePath(day);
+  await ensureDir(queuePath);
+  await fs.appendFile(queuePath, `${JSON.stringify({
+    ...requestInfo,
+    clientKey,
+    queuedAt: new Date().toISOString(),
+  })}\n`, 'utf8');
+
+  return limitInfo(client, dailyLimit(), day);
+}
+
+export function hasInFlightGeneration(appKey: string) {
+  return inFlightGenerations.has(appKey);
+}
+
+export async function runDedupedGeneration<T>(appKey: string, generate: () => Promise<T>) {
+  const existing = inFlightGenerations.get(appKey) as Promise<T> | undefined;
+  if (existing) {
+    return {
+      deduped: true,
+      result: await existing,
+    };
+  }
+
+  const promise = generate().finally(() => {
+    inFlightGenerations.delete(appKey);
+  });
+
+  inFlightGenerations.set(appKey, promise);
+
+  return {
+    deduped: false,
+    result: await promise,
+  };
+}

--- a/src/lib/appstore/review-history.ts
+++ b/src/lib/appstore/review-history.ts
@@ -1,0 +1,94 @@
+import 'server-only';
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { AppStoreLookupResult, normalizeCountry } from '@/lib/appstore/discovery';
+import { AppStoreReview } from '@/types';
+
+interface ReviewHistoryFile {
+  version: 1;
+  app: Pick<AppStoreLookupResult, 'id' | 'name' | 'country' | 'artistName' | 'artworkUrl' | 'trackViewUrl' | 'primaryGenreName'>;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  totalReviews: number;
+  reviews: AppStoreReview[];
+}
+
+function historyRoot() {
+  return process.env.APP_REVIEW_HISTORY_DIR
+    || path.join(
+      process.env.APP_REVIEW_CACHE_DIR || path.join(process.cwd(), 'src', 'data', 'app-cache'),
+      '.review-history'
+    );
+}
+
+function safeHistoryKey(country: string, appId: string) {
+  return `${normalizeCountry(country)}-${appId.replace(/\D/g, '')}`;
+}
+
+function historyFilePath(country: string, appId: string) {
+  return path.join(historyRoot(), `${safeHistoryKey(country, appId)}.json`);
+}
+
+function sortReviewsByDateDesc(reviews: AppStoreReview[]) {
+  return [...reviews].sort((a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime());
+}
+
+async function readHistory(country: string, appId: string): Promise<ReviewHistoryFile | null> {
+  try {
+    const content = await fs.readFile(historyFilePath(country, appId), 'utf8');
+    return JSON.parse(content) as ReviewHistoryFile;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+async function atomicWriteJson(filePath: string, data: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+export async function upsertReviewHistory(app: AppStoreLookupResult, reviews: AppStoreReview[]) {
+  if (reviews.length === 0) return;
+
+  const country = normalizeCountry(app.country);
+  const existing = await readHistory(country, app.id);
+  const byId = new Map<string, AppStoreReview>();
+
+  for (const review of existing?.reviews || []) {
+    byId.set(review.id, review);
+  }
+
+  for (const review of reviews) {
+    byId.set(review.id, {
+      ...review,
+      appId: review.appId || app.id,
+      country: normalizeCountry(review.country || country),
+      sourceCountry: review.sourceCountry ? normalizeCountry(review.sourceCountry) : country,
+    });
+  }
+
+  const now = new Date().toISOString();
+  const mergedReviews = sortReviewsByDateDesc(Array.from(byId.values()));
+  const history: ReviewHistoryFile = {
+    version: 1,
+    app: {
+      id: app.id,
+      name: app.name,
+      country,
+      artistName: app.artistName,
+      artworkUrl: app.artworkUrl,
+      trackViewUrl: app.trackViewUrl,
+      primaryGenreName: app.primaryGenreName,
+    },
+    firstSeenAt: existing?.firstSeenAt || now,
+    lastSeenAt: now,
+    totalReviews: mergedReviews.length,
+    reviews: mergedReviews,
+  };
+
+  await atomicWriteJson(historyFilePath(country, app.id), history);
+}


### PR DESCRIPTION
## Summary
- add public generation guard with per-day client quota, 3-day fresh cache reuse, in-flight dedupe, and queued requests
- remove public Top10 batch generation, add reward support dialog on rate limits, and simplify the detail action to one incremental update button
- archive fetched review history per app for future trend analysis
- update header/footer brand to 乔木App洞察, remove hero title, and add search clear interaction

## Verification
- npx eslint src/app/api/research/route.ts src/app/api/research/regenerate/route.ts src/app/apps/[country]/[appId]/[[...slug]]/page.tsx src/lib/appstore/cache.ts src/lib/appstore/generation-guard.ts src/lib/appstore/review-history.ts src/lib/appstore/diagnostics.ts src/components/app-review/home-client.tsx src/components/app-review/top-charts-section.tsx src/components/app-review/regenerate-button.tsx src/components/app-review/site-footer.tsx
- npm run build
- local zero-limit empty-cache POST returns 429 and writes queue JSONL
- local zero-limit cached ChatGPT POST returns 200 cached with generation.status=cached
- deployed to qiaomu-appreview.service and verified https://appreview.qiaomu.ai/api/health
- live homepage/detail HTML checks pass for brand, clear button, removed batch Top10, removed internal optimization copy, and update-only detail action
