### PR TITLE
Redesign app review brand mark

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,1 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" role="img" aria-label="Option 07"><defs><linearGradient id="option-07-bg" x1="14.644660940672622%" y1="14.644660940672622%" x2="85.35533905932738%" y2="85.35533905932738%"><stop offset="0" stop-color="#111827"/><stop offset="1" stop-color="#0f766e"/></linearGradient><linearGradient id="option-07-fg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#fbbf24"/><stop offset="1" stop-color="#ffffff"/></linearGradient></defs><rect width="1024" height="1024" fill="url(#option-07-bg)"/><g filter="drop-shadow(0 25.6px 35.84px rgba(15,23,42,0.16))"><path transform="translate(512 512) rotate(0) scale(25.598170848210657) translate(-12 -12)" d="M12 8a4 4 0 100 8 4 4 0 000-8zm8.94 3A8.994 8.994 0 0013 3.06V1h-2v2.06A8.994 8.994 0 003.06 11H1v2h2.06A8.994 8.994 0 0011 20.94V23h2v-2.06A8.994 8.994 0 0020.94 13H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z" fill="url(#option-07-fg)"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" role="img" aria-label="Qiaomu App Insights logo">
+  <rect width="1024" height="1024" rx="224" fill="#09090b"/>
+  <g fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M512 234v560" stroke-width="82"/>
+    <path d="M296 414h432" stroke-width="76"/>
+    <path d="M512 470 314 706" stroke-width="74"/>
+    <path d="M512 470 710 706" stroke-width="74"/>
+  </g>
+  <circle cx="708" cy="292" r="44" fill="#f8fafc"/>
+  <circle cx="708" cy="292" r="17" fill="#09090b"/>
+</svg>

--- a/src/components/app-review/site-footer.tsx
+++ b/src/components/app-review/site-footer.tsx
@@ -22,10 +22,11 @@ const profileLinks = [
 function BrandName({ className = 'text-lg' }: { className?: string }) {
   return (
     <p
-      className={`${className} font-semibold leading-none text-zinc-950`}
-      style={{ fontFamily: '"Noto Serif SC", "Source Han Serif SC", "Songti SC", "STSong", SimSun, serif' }}
+      className={`${className} inline-flex items-baseline gap-1.5 whitespace-nowrap leading-none`}
+      style={{ fontFamily: '"PingFang SC", "Hiragino Sans GB", "Noto Sans CJK SC", "Source Han Sans SC", "Microsoft YaHei", system-ui, sans-serif' }}
     >
-      乔木App洞察
+      <span className="text-zinc-950" style={{ fontWeight: 760 }}>乔木</span>
+      <span className="text-zinc-800" style={{ fontWeight: 620 }}>App洞察</span>
     </p>
   );
 }
@@ -33,8 +34,12 @@ function BrandName({ className = 'text-lg' }: { className?: string }) {
 export function BrandMark({ compact = false }: { compact?: boolean }) {
   return (
     <div className="flex items-center gap-3">
-      <img src="/logo.svg" alt="乔木App洞察 Logo" className={`${compact ? 'h-9 w-9' : 'h-10 w-10'} rounded-lg shadow-sm`} />
-      <BrandName className={compact ? 'text-lg' : 'text-xl'} />
+      <img
+        src="/logo.svg"
+        alt="乔木App洞察 Logo"
+        className={`${compact ? 'h-9 w-9 rounded-[10px]' : 'h-10 w-10 rounded-xl'} shrink-0 ring-1 ring-zinc-950/10`}
+      />
+      <BrandName className={compact ? 'text-[18px]' : 'text-[20px]'} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the old gradient target logo with a black square mark based on a stylized 木 and insight dot
- update the header/footer wordmark typography from serif fallback to a cleaner modern Chinese sans stack
- remove logo shadow treatment and use a tighter ring for the black mark

## Verification
- npx eslint src/components/app-review/site-footer.tsx
- npm run build
- rendered 512/64/32px logo previews with sharp to confirm favicon-scale legibility
- deployed to qiaomu-appreview.service and verified https://appreview.qiaomu.ai/api/health
- verified https://appreview.qiaomu.ai/logo.svg contains the black mark and no old gradient
- verified live homepage contains PingFang SC wordmark stack and no old Songti/STSong fallback
