### PR TITLE
Replace ambiguous app review logo

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,11 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" role="img" aria-label="Qiaomu App Insights logo">
   <rect width="1024" height="1024" rx="224" fill="#09090b"/>
-  <g fill="none" stroke="#f8fafc" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M512 234v560" stroke-width="82"/>
-    <path d="M296 414h432" stroke-width="76"/>
-    <path d="M512 470 314 706" stroke-width="74"/>
-    <path d="M512 470 710 706" stroke-width="74"/>
-  </g>
-  <circle cx="708" cy="292" r="44" fill="#f8fafc"/>
-  <circle cx="708" cy="292" r="17" fill="#09090b"/>
+  <rect x="248" y="226" width="386" height="548" rx="92" fill="none" stroke="#f8fafc" stroke-width="56" opacity=".42"/>
+  <rect x="330" y="258" width="446" height="566" rx="104" fill="#f8fafc"/>
+  <rect x="408" y="344" width="106" height="106" rx="30" fill="#09090b"/>
+  <rect x="552" y="352" width="142" height="34" rx="17" fill="#09090b" opacity=".92"/>
+  <rect x="552" y="414" width="96" height="30" rx="15" fill="#09090b" opacity=".56"/>
+  <path d="M420 676 506 590 586 630 692 506" fill="none" stroke="#09090b" stroke-width="54" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M648 506h44v44" fill="none" stroke="#09090b" stroke-width="44" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- replace the stylized 木 + insight dot mark because it can be misread as 术
- use a non-text black product symbol: layered app cards, review rows, and an insight trend arrow
- keep the existing wordmark typography from the prior brand update

## Verification
- rendered 512/64/32px previews with sharp and checked small-size legibility
- npx eslint src/components/app-review/site-footer.tsx
- npm run build
- deployed to qiaomu-appreview.service and verified https://appreview.qiaomu.ai/api/health
- verified live logo.svg contains the app-card mark, has no old wood path, no gradient, and matches local SHA256
