### PR TITLE
fix: make site copy product insight focused

### DIFF
--- a/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
+++ b/src/app/apps/[country]/[appId]/[[...slug]]/page.tsx
@@ -98,7 +98,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       `${cached.app.name}评论`,
       'App Store评论分析',
       '用户反馈挖掘',
-      'DeepSeek flash',
+      '产品机会挖掘',
+      '竞品评价分析',
       '产品需求分析',
     ],
     alternates: {
@@ -204,7 +205,7 @@ export default async function AppInsightPage({ params }: PageProps) {
                 </h1>
                 <p className="mt-2 text-sm text-zinc-500">{page.app.artistName || 'App Store'} · 更新于 {formatDate(page.updatedAt)}</p>
                 <p className="mt-4 max-w-3xl text-base leading-7 text-zinc-700">
-                  本页基于 App Store 用户评价生成，面向产品分析和竞品研究，保留评论证据、来源构成和样本边界，并用 DeepSeek flash 提炼可行动信号。
+                  本页基于 App Store 用户评价生成，面向产品分析和竞品研究，保留评论证据、来源构成和样本边界，并提炼可行动信号。
                 </p>
               </div>
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
     default: "乔木App评价洞察",
     template: "%s | 乔木App评价洞察",
   },
-  description: "搜索任意 iOS App，生成 App Store 用户评价洞察页，用 DeepSeek flash 挖掘痛点、机会和版本风险。",
+  description: "搜索任意 iOS App，生成 App Store 用户评价洞察页，提炼痛点、机会和版本风险。",
   applicationName: "乔木App评价洞察",
   icons: {
     icon: "/logo.svg",
@@ -27,7 +27,7 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary",
     title: "乔木App评价洞察",
-    description: "用 DeepSeek flash 挖掘 App Store 用户评价里的产品信号。",
+    description: "挖掘 App Store 用户评价里的痛点、机会和版本风险。",
   },
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,14 +10,15 @@ import {
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  title: '乔木App评价洞察 - App Store用户评价分析与DeepSeek信息挖掘',
-  description: '搜索任意 iOS App，生成用户评价洞察页面，用 DeepSeek flash 从 App Store 评论中提炼痛点、机会、版本风险和用户需求。',
+  title: '乔木App评价洞察 - App Store用户评价分析与产品机会挖掘',
+  description: '搜索任意 iOS App，生成用户评价洞察页面，从 App Store 评论中提炼痛点、机会、版本风险和用户需求。',
   keywords: [
     '乔木App评价洞察',
     'App评价分析',
     'App Store评论分析',
     '用户反馈挖掘',
-    'DeepSeek flash',
+    '产品机会挖掘',
+    '竞品评价分析',
     '产品需求分析',
   ],
   alternates: {

--- a/src/components/app-review/home-client.tsx
+++ b/src/components/app-review/home-client.tsx
@@ -591,7 +591,7 @@ export default function Home({
           <section className="mt-4 rounded-lg border border-zinc-200 bg-white p-5 shadow-sm">
             <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
               <div>
-                <h2 className="text-lg font-semibold text-zinc-950">DeepSeek 信息挖掘</h2>
+                <h2 className="text-lg font-semibold text-zinc-950">用户评价洞察</h2>
                 <p className="mt-1 text-sm text-zinc-500">
                   {result.model ? `${result.model.provider} · ${result.model.model}` : '评论证据优先'}
                 </p>


### PR DESCRIPTION
## Summary
- Remove DeepSeek-first wording from public metadata and visible site copy
- Reframe homepage and app detail pages around user review insight, product opportunities, pain points, and version risks
- Keep provider/model visibility only as secondary status text

## Verification
- npm run build
- rg check for DeepSeek/SEO/GEO lead-copy leftovers under src/app and src/components/app-review